### PR TITLE
3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,8 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
+![update][update]
+
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
 ```typescript
@@ -987,6 +989,8 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 ----
 
 ### isObjectKeyIn
+
+![https://img.shields.io/badge/-New-green](https://img.shields.io/badge/-New-green)
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
 More about operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) used in the function.
@@ -2081,7 +2085,8 @@ MIT © angular-package ([license](https://github.com/angular-package/type/blob/m
 [symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 [symbolconstructor]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
 
-[new]: https://img.shields.io/badge/-new-red
+[new]: https://img.shields.io/badge/-new-green
+[update]: https://img.shields.io/badge/-update-red
 
 [type-npm-svg]: https://badge.fury.io/js/%40angular-package%2Ftype.svg
 [type-npm-badge]: https://badge.fury.io/js/%40angular-package%2Ftype

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ import {
   isNumberType,
   isObject,
   isObjectKey,
+  isObjectKeyIn,
   isPrimitive,
   isString,
   isStringObject,
@@ -112,6 +113,7 @@ import { Constructor, CycleHook, Func, Key, Primitive, Primitives, ResultCallbac
     * a `number` type and **not** instance of [`Number`][Number] and [`Object`][object] with [`isNumberType()`](#isnumbertype).
     * a generic type `object` with [`isObject()`](#isobject).
     * an `object` with its own specified [`Key`][key] with [`isObjectKey()`](#isobjectkey).
+    * an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
     * a one of the primitive `boolean`, `bigint`, `number`, `string` with [`isPrimitive()`](#isPrimitive).
     * a `string` with [`isString()`](#isstring).
     * an `object` type and instance of [`String`][string] and [`Object`][object] with [`isStringObject()`](#isstringobject).
@@ -818,7 +820,6 @@ const OBJECT_ONE: ObjectOne = {
 };
 
 isObject(OBJECT_ONE); // true
-isObject(OBJECT_ONE, 'key as string'); // true
 isObject(OBJECT_ONE, STRING); // true
 isObject(OBJECT_ONE, STRING_NEW_INSTANCE); // true
 isObject(OBJECT_ONE, 1030405027); // true
@@ -860,6 +861,38 @@ const isObjectKey: IsObjectKey = <Type extends object>(
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys.
+
+----
+
+### isObjectKeyIn
+
+Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
+
+```typescript
+const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(
+  value: any,
+  key: Key | Key[],
+  callback: ResultCallback = resultCallback
+): value is Type =>
+  callback(
+    isObject<Type>(value) ?
+      isArray(key) ?
+        key.every(k => isKey(k) ? k in value : false)
+      : isKey(key) ?
+          key in value
+        : false
+    : false,
+    value
+  );
+```
+
+| Parameter | Type                             | Description                                           |
+| :-------- | :------------------------------: | :---------------------------------------------------- |
+| value     | `any`                            | Any `value` to check if it contains a specified `key` |
+| key       | [`Key`][key] \| [`Key`][key][] | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+
+The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ isBooleanType(BOOLEAN_INSTANCE); // false
 
 ### isDefined
 
-Use `isDefined()` or `is.defined()` to check if an **unknown** `value` is NOT an `undefined` type and is NOT equal to `undefined`.
+Use `isDefined()` or `is.defined()` to check if an **unknown** `value` is **not** an `undefined` type and is **not** equal to `undefined`.
 
 ```typescript
 const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
@@ -743,6 +743,8 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 ### isObject
 
 ![update][update]
+
+* Removed `key` parameter. Use [`isObjectKeyIn`](#isobjectkin) instead.
 
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ import { Constructor, CycleHook, Func, Key, Primitive, Primitives, ResultCallbac
     * a `number` with [`isNumber()`](#isnumber).
     * an `object` type and instance of [`Number`][Number] and [`Object`][object] with [`isNumberObject()`](#isnumberobject).
     * a `number` type and **not** instance of [`Number`][Number] and [`Object`][object] with [`isNumberType()`](#isnumbertype).
-    * ![update][update] a generic type `object` with [`isObject()`](#isobject).
+    * a generic type `object` with [`isObject()`](#isobject).
     * an `object` with its own specified [`Key`][key] with [`isObjectKey()`](#isobjectkey).
-    * ![new][new] an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
+    * an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
     * a one of the primitive `boolean`, `bigint`, `number`, `string` with [`isPrimitive()`](#isPrimitive).
     * a `string` with [`isString()`](#isstring).
     * an `object` type and instance of [`String`][string] and [`Object`][object] with [`isStringObject()`](#isstringobject).

--- a/README.md
+++ b/README.md
@@ -194,8 +194,15 @@ npm i --save @angular-package/type
 Default function to handle `callback`.
 
 ```typescript
-const resultCallback: ResultCallback = (result: boolean): boolean => result;
+const resultCallback: ResultCallback = (result: boolean, value?: any): boolean => result;
 ```
+
+| Parameter | Type      | Description                             |
+| :-------- | :-------: | :-------------------------------------- |
+| result    | `boolean` | A `boolean` type value from the result of the check   |
+| value     | `any`     | Any type value from the check |
+
+The **return value** is a `boolean` type result from the check.
 
 Custom function to handle `callback`.
 
@@ -258,7 +265,7 @@ const is: Is = {
   defined: isDefined,
   function: isFunction,
   instance: isInstance,
-  key: iskey,
+  key: isKey,
   not: isNot,
   null: isNull,
   number: isNumber,
@@ -288,7 +295,8 @@ const isArray: IsArray = <Type>(value: any, callback: ResultCallback = resultCal
     typeOf(value) === 'array' &&
     Array.isArray(value) === true &&
     value instanceof Array === true &&
-    typeof value === 'object'
+    typeof value === 'object',
+    value
   );
 ```
 
@@ -318,7 +326,7 @@ Use `isBigInt()` or `is.bigint()` to check if **any** `value` is a `bigint` type
 
 ```typescript
 const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallback): value is bigint =>
-  callback(typeOf(value) === 'bigint' && typeof value === 'bigint');
+  callback(typeOf(value) === 'bigint' && typeof value === 'bigint', value);
 ```
 
 | Parameter | Type  | Description |
@@ -347,7 +355,7 @@ Use `isBoolean()` or `is.boolean()` to check if **any** `value` is a `boolean` t
 
 ```typescript
 const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallback): value is boolean =>
-  callback(typeOf(value) === 'boolean' && (isBooleanType(value) || isBooleanObject(value)));
+  callback(typeOf(value) === 'boolean' && (isBooleanType(value) || isBooleanObject(value)), value);
 ```
 
 | Parameter | Type  | Description          |
@@ -376,7 +384,7 @@ Use `isBooleanObject()` or `is.booleanObject()` to check if **any** `value` is a
 
 ```typescript
 const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback = resultCallback): value is boolean =>
-  callback(typeof value === 'object' && value instanceof Boolean === true && value instanceof Object === true);
+  callback(typeof value === 'object' && value instanceof Boolean === true && value instanceof Object === true, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -407,7 +415,8 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
     value instanceof Boolean === false &&
     value instanceof Object === false &&
     typeof value === 'boolean' &&
-    (value === true || value === false)
+    (value === true || value === false),
+    value
   );
 ```
 
@@ -435,7 +444,7 @@ Use `isDefined()` or `is.defined()` to check if an **unknown** `value` is NOT an
 
 ```typescript
 const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined);
+  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
 ```
 
 | Parameter | Type      | Description                   |
@@ -466,7 +475,8 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
     typeOf(value) === 'function' &&
     typeof value === 'function' &&
     value instanceof Function === true &&
-    value instanceof Object === true
+    value instanceof Object === true,
+    value
   );
 ```
 
@@ -506,7 +516,8 @@ const isInstance: IsInstance = <Obj>(
         isFunction(instance) ?
           value instanceof instance === true
         : false
-      : false
+      : false,
+      value
     );
 ```
 
@@ -541,7 +552,7 @@ Use `isKey()` or `is.key()` to check if **any** `value` is one of the `string`, 
 
 ```typescript
 const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): value is Key =>
-  callback(isString(value) || isNumber(value) || isSymbol(value));
+  callback(isString(value) || isNumber(value) || isSymbol(value), value);
 ```
 
 | Parameter | Type  | Description          |
@@ -577,7 +588,7 @@ Use `isNull()` or `is.null()` to check if **any** `value` is an `object` type an
 
 ```typescript
 const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): value is null =>
-  callback(typeOf(value) === 'null' && typeof value === 'object' && value === null);
+  callback(typeOf(value) === 'null' && typeof value === 'object' && value === null, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -612,7 +623,7 @@ Use `isNumber()` or `is.number()` to check if **any** `value` is a `number` type
 
 ```typescript
 const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(typeOf(value) === 'number' && isFinite(value) === true && (isNumberType(value) || isNumberObject(value)));
+  callback(typeOf(value) === 'number' && isFinite(value) === true && (isNumberType(value) || isNumberObject(value)), value);
 ```
 
 | Parameter | Type  | Description          |
@@ -632,7 +643,7 @@ Use `isNumberObject()` or `is.numberObject()` to check if **any** `value` is an 
 
 ```typescript
 const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(typeof value === 'object' && value instanceof Number === true && value instanceof Object === true);
+  callback(typeof value === 'object' && value instanceof Number === true && value instanceof Object === true, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -681,7 +692,7 @@ Use `isNumberType()` or `is.numberType()` to check if **any** `value` is a `numb
 
 ```typescript
 const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(value instanceof Number === false && value instanceof Object === false && typeof value === 'number');
+  callback(value instanceof Number === false && value instanceof Object === false && typeof value === 'number', value);
 ```
 
 | Parameter | Type  | Description          |
@@ -726,21 +737,17 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
-Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance with the possibility of containing the `key`.
+Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
 ```typescript
-const isObject: IsObject = <Obj = object>(value: any, key?: Key): value is Obj =>
-  (typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true)
-    ? isKey(key)
-      ? key in value
-    : true
-  : false;
+const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback = resultCallback): value is Obj =>
+  callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);
 ```
 
 | Parameter | Type          | Description |
 | :-------- | :-----------: | :---------- |
 | value     | `any`         | Any `value` to check |
-| key?      | [`Key`][key] | Property name to find in the `value` |
+| callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object`.
 
@@ -841,7 +848,8 @@ const isObjectKey: IsObjectKey = <Type extends object>(
       : isKey(key) ?
           ({}).hasOwnProperty.call(value, key)
         : false
-    : false
+    : false,
+    value
   );
 ```
 
@@ -898,7 +906,7 @@ Use `isString()` or `is.string()` to check if **any** `value` is a `string` type
 
 ```typescript
 const isString: IsString = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(typeOf(value) === 'string' && (isStringType(value) || isStringObject(value)));
+  callback(typeOf(value) === 'string' && (isStringType(value) || isStringObject(value)), value);
 ```
 
 | Parameter |       Type                          | Description          |
@@ -916,7 +924,7 @@ Use `isStringObject()` or `is.stringObject()` to check if **any** `value` is an 
 
 ```typescript
 const isStringObject: IsStringObject = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(value instanceof Object === true && value instanceof String === true && typeof value === 'object');
+  callback(value instanceof Object === true && value instanceof String === true && typeof value === 'object', value);
 ```
 
 | Parameter |       Type                          | Description          |
@@ -934,7 +942,7 @@ Use `isStringType()` or `is.stringType()` to check if **any** `value` is a `stri
 
 ```typescript
 const isStringType: IsStringType = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string');
+  callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string', value);
 ```
 
 | Parameter | Type                                                                    | Description          |
@@ -952,7 +960,7 @@ Use `isSymbol()` or `is.symbol()` to check if **any** `value` is a `symbol` type
 
 ```typescript
 const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallback): value is symbol =>
-  callback(typeOf(value) === 'symbol' && typeof value === 'symbol');
+  callback(typeOf(value) === 'symbol' && typeof value === 'symbol', value);
 ```
 
 | Parameter | Type  | Description          |
@@ -1013,7 +1021,7 @@ Use `isUndefined()` or `is.undefined()` to check if **any** `value` is an `undef
 
 ```typescript
 const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultCallback): value is undefined =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined);
+  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -1054,7 +1062,8 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
     typeof value !== 'boolean' &&
     value instanceof Boolean === false &&
     value !== true &&
-    value !== false
+    value !== false,
+    value
   );
 ```
 
@@ -1073,7 +1082,7 @@ Use `isNotDefined()` or `is.not.defined()` to check if an **unknown** `value` is
 
 ```typescript
 const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined);
+  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1091,7 +1100,7 @@ Use `isNotFunction()` or `is.not.function()` to check if an **unknown** `value` 
 
 ```typescript
 const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false);
+  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1109,7 +1118,7 @@ Use `isNotNull()` or `is.not.null()` to check if an **unknown** `value` is **not
 
 ```typescript
 const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'null' && value !== null);
+  callback(typeOf(value) !== 'null' && value !== null, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1130,7 +1139,8 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
   callback(
     typeOf(value) !== 'number' &&
     typeof value !== 'number' &&
-    value instanceof Number === false
+    value instanceof Number === false,
+    value
   );
 ```
 
@@ -1149,7 +1159,7 @@ Use `isNotString()` or `is.not.string()` to check if an **unknown** `value` is *
 
 ```typescript
 const isNotString: IsNotString = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false);
+  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1167,7 +1177,7 @@ Use `isNotUndefined()` or `is.not.undefined()` to check if an **unknown** `value
 
 ```typescript
 const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined);
+  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
 ```
 
 | Parameter | Type      | Description                 |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ import {
   isType,
   isUndefined
 } from '@angular-package/type';
+```
 
+```typescript
 // `are` prefix functions.
 import {
   areString

--- a/README.md
+++ b/README.md
@@ -764,57 +764,6 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ```typescript
 // Example usage
-const SYMBOL_NUMBER: unique symbol = Symbol(NUMBER);
-const SYMBOL_STRING: unique symbol = Symbol(STRING);
-
-/**
- * typeof === 'number'
- * instanceof Function === false
- * instanceof Number === false
- * instanceof Object === false
- */
-const NUMBER: any = 10304050;
-
-/**
- * typeof === 'number'
- * instanceof Function === false
- * instanceof Number === false
- * instanceof Object === false
- */
-const NUMBER_INSTANCE: any = Number(NUMBER);
-
-/**
- * typeof === 'number'
- * instanceof Function === false
- * instanceof Number === true
- * instanceof Object === true
- */
-const NUMBER_NEW_INSTANCE: any = new Number(NUMBER);
-
-/**
- * typeof === 'string'
- * instanceof Function === false
- * instanceof Object === false
- * instanceof String === false
- */
-const STRING: any = '!@#$%^&*()abcdefghijklmnoprstuwyz';
-
-/**
- * typeof === 'string'
- * instanceof Function === false
- * instanceof Object === false
- * instanceof String === false
- */
-const STRING_INSTANCE: any = String(STRING);
-
-/**
- * typeof === 'string'
- * instanceof Function === false
- * instanceof Object === true
- * instanceof String === true
- */
-const STRING_NEW_INSTANCE: any = new String(STRING);
-
 const OBJECT_ONE: ObjectOne = {
   'key as string': true,
   1030405027: 'key is number',
@@ -827,13 +776,6 @@ const OBJECT_ONE: ObjectOne = {
 };
 
 isObject(OBJECT_ONE); // true
-isObject(OBJECT_ONE, STRING); // true
-isObject(OBJECT_ONE, STRING_NEW_INSTANCE); // true
-isObject(OBJECT_ONE, 1030405027); // true
-isObject(OBJECT_ONE, NUMBER); // true
-isObject(OBJECT_ONE, NUMBER_NEW_INSTANCE); // true
-isObject(OBJECT_ONE, SYMBOL_NUMBER); // true
-isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ```
 
@@ -982,7 +924,7 @@ export class Class {
  */
 export const CLASS = new Class();
 
-// One of the differences between `in` operator and the `hasOwnProperty()` method is that it doesn't find a getter key
+// One of the differences between the `in` operator and the `hasOwnProperty()` method is that it doesn't find a getter key
 isObjectKey(CLASS, SYMBOL_NUMBER); // false
 isObjectKey(CLASS, SYMBOL_STRING); // false
 isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
@@ -993,7 +935,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ### isObjectKeyIn
 
-![https://img.shields.io/badge/-New-green](https://img.shields.io/badge/-New-green)
+![new][new]
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
@@ -1123,7 +1065,7 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | Parameter |       Type                          | Description          |
 | :-------- | :---------------------------------: | :------------------- |
 | value     | `any`                               | Any `value` to check |
-| callback  | [`ResultCallback`][resultcallback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+| callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is a `string`.
 
@@ -1156,9 +1098,9 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
   callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string', value);
 ```
 
-| Parameter | Type                                                                    | Description          |
-| :-------- | :---------------------------------------------------------------------: | :------------------- |
-| value     | `any`                                                                   | Any `value` to check |
+| Parameter | Type                                                            | Description          |
+| :-------- | :-------------------------------------------------------------: | :------------------- |
+| value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is a `string`.
@@ -1397,6 +1339,33 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The return value is a `boolean` indicating whether or not the `value` is not `undefined`.
+
+```typescript
+// Example usage with the problem
+interface Config {
+  a?: string;
+  b?: string;
+}
+let config: Config = {
+  a: 'x',
+  b: 'y'
+};
+
+function configFunction(value: string): string {
+  return '';
+}
+
+// Cause typescript return `boolean` this will generate an type error
+if (is.not.undefined(config.a)) {
+  configFunction(config.a);
+}
+
+// Cause typescript return `value is boolean` this will not generate an error
+if (!is.undefined(config.a)) {
+  configFunction(config.a);
+}
+
+```
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ const is: Is = {
   numberType: isNumberType,
   object: isObject,
   objectKey: isObjectKey,
+  objectKeyIn: isObjectKeyIn,
   primitive: isPrimitive,
   string: isString,
   stringObject: isStringObject,
@@ -834,7 +835,8 @@ isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ### isObjectKey
 
-Use `isObject()` or `is.object()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
+Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
+More about [`hasOwnProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) method used in the function.
 
 ```typescript
 const isObjectKey: IsObjectKey = <Type extends object>(
@@ -862,11 +864,132 @@ const isObjectKey: IsObjectKey = <Type extends object>(
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys.
 
+```typescript
+// Example usage
+const SYMBOL_NUMBER: unique symbol = Symbol(NUMBER);
+const SYMBOL_STRING: unique symbol = Symbol(STRING);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER: any = 10304050;
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER_INSTANCE: any = Number(NUMBER);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === true
+ * instanceof Object === true
+ */
+const NUMBER_NEW_INSTANCE: any = new Number(NUMBER);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING: any = '!@#$%^&*()abcdefghijklmnoprstuwyz';
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING_INSTANCE: any = String(STRING);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === true
+ * instanceof String === true
+ */
+const STRING_NEW_INSTANCE: any = new String(STRING);
+
+const OBJECT_ONE: ObjectOne = {
+  'key as string': true,
+  1030405027: 'key is number',
+  5: 'key is also number',
+  [NUMBER]: 'key is number',
+  [string]: 'key is string',
+  [SYMBOL_NUMBER]: 'key is symbol number',
+  [SYMBOL_STRING]: 6,
+  x: 3000
+};
+
+isObjectKey(OBJECT_ONE, STRING); // true
+isObjectKey(OBJECT_ONE, STRING_NEW_INSTANCE); // true
+isObjectKey(OBJECT_ONE, 1030405027); // true
+isObjectKey(OBJECT_ONE, NUMBER); // true
+isObjectKey(OBJECT_ONE, NUMBER_NEW_INSTANCE); // true
+isObjectKey(OBJECT_ONE, SYMBOL_NUMBER); // true
+isObjectKey(OBJECT_ONE, SYMBOL_STRING); // true
+
+/**
+ * typeof === 'function'
+ * instanceof Class === false
+ * instanceof Function === true
+ * instanceof Object === true
+ */
+export class Class {
+
+  1030405027 = 'my new number';
+  5 = 'my number';
+
+  firstName = 'My name';
+  surname = 'Surname';
+
+  x = NUMBER;
+  y = STRING;
+
+  get [NUMBER](): number {
+    return this.x;
+  }
+  get [STRING](): string {
+    return this.y;
+  }
+
+  get [SYMBOL_NUMBER](): number {
+    return this.x;
+  }
+
+  get [SYMBOL_STRING](): string {
+    return this.y;
+  }
+}
+
+/**
+ * typeof === 'object'
+ * instanceof Class === true
+ * instanceof Function === false
+ * instanceof Object === true
+ */
+export const CLASS = new Class();
+
+// One of the differences between `in` operator and the `hasOwnProperty()` method is that it doesn't find a getter key
+isObjectKey(CLASS, SYMBOL_NUMBER); // false
+isObjectKey(CLASS, SYMBOL_STRING); // false
+isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
+ 
+```
+
 ----
 
 ### isObjectKeyIn
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
+More about operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) used in the function.
 
 ```typescript
 const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(
@@ -893,6 +1016,55 @@ const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys.
+
+```typescript
+/**
+ * typeof === 'function'
+ * instanceof Class === false
+ * instanceof Function === true
+ * instanceof Object === true
+ */
+export class Class {
+
+  1030405027 = 'my new number';
+  5 = 'my number';
+
+  firstName = 'My name';
+  surname = 'Surname';
+
+  x = NUMBER;
+  y = STRING;
+
+  get [NUMBER](): number {
+    return this.x;
+  }
+  get [STRING](): string {
+    return this.y;
+  }
+
+  get [SYMBOL_NUMBER](): number {
+    return this.x;
+  }
+
+  get [SYMBOL_STRING](): string {
+    return this.y;
+  }
+}
+
+/**
+ * typeof === 'object'
+ * instanceof Class === true
+ * instanceof Function === false
+ * instanceof Object === true
+ */
+export const CLASS = new Class();
+
+// One of the differences between `in` operator and the `hasOwnProperty()` method is that it finds a getter key
+isObjectKeyIn(OBJECT_ONE, SYMBOL_NUMBER); // true
+isObjectKeyIn(OBJECT_ONE, SYMBOL_STRING); // true
+isObjectKeyIn(OBJECT_ONE, [SYMBOL_NUMBER, SYMBOL_STRING]); // true
+
+```
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import {
 ```
 
 ```typescript
-// Check `is` prefix functions.
+// `is` prefix functions.
 import {
   isArray,
   isBigInt,
@@ -68,12 +68,15 @@ import {
   isType,
   isUndefined
 } from '@angular-package/type';
-// Check `are` prefix functions.
-import { areString } from '@angular-package/type';
+
+// `are` prefix functions.
+import {
+  areString
+} from '@angular-package/type';
 ```
 
 ```typescript
-// Check `isNot` prefix functions.
+// `isNot` prefix functions.
 import {
   isNotBoolean,
   isNotDefined,

--- a/README.md
+++ b/README.md
@@ -742,21 +742,21 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
-![update][update]
-
-* Removed `key` parameter. Use [`isObjectKeyIn`](#isobjectkin) instead.
-
-Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
+Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance with the possibility of containing the `key`.
 
 ```typescript
-const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback = resultCallback): value is Obj =>
-  callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);
+const isObject: IsObject = <Obj = object>(value: any, key?: Key): value is Obj =>
+  (typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true)
+    ? isKey(key)
+      ? key in value
+    : true
+  : false;
 ```
 
 | Parameter | Type          | Description |
 | :-------- | :-----------: | :---------- |
 | value     | `any`         | Any `value` to check |
-| callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+| key?      | [`Key`][key] | Property name to find in the `value` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object`.
 
@@ -764,6 +764,57 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ```typescript
 // Example usage
+const SYMBOL_NUMBER: unique symbol = Symbol(NUMBER);
+const SYMBOL_STRING: unique symbol = Symbol(STRING);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER: any = 10304050;
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER_INSTANCE: any = Number(NUMBER);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === true
+ * instanceof Object === true
+ */
+const NUMBER_NEW_INSTANCE: any = new Number(NUMBER);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING: any = '!@#$%^&*()abcdefghijklmnoprstuwyz';
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING_INSTANCE: any = String(STRING);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === true
+ * instanceof String === true
+ */
+const STRING_NEW_INSTANCE: any = new String(STRING);
+
 const OBJECT_ONE: ObjectOne = {
   'key as string': true,
   1030405027: 'key is number',
@@ -776,6 +827,14 @@ const OBJECT_ONE: ObjectOne = {
 };
 
 isObject(OBJECT_ONE); // true
+isObject(OBJECT_ONE, 'key as string'); // true
+isObject(OBJECT_ONE, STRING); // true
+isObject(OBJECT_ONE, STRING_NEW_INSTANCE); // true
+isObject(OBJECT_ONE, 1030405027); // true
+isObject(OBJECT_ONE, NUMBER); // true
+isObject(OBJECT_ONE, NUMBER_NEW_INSTANCE); // true
+isObject(OBJECT_ONE, SYMBOL_NUMBER); // true
+isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -837,8 +837,7 @@ isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ### isObjectKey
 
-Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
-More about [`hasOwnProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) method used in the function.
+Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key]. The Function uses [`hasOwnProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) method to find the key.
 
 ```typescript
 const isObjectKey: IsObjectKey = <Type extends object>(
@@ -992,8 +991,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ![https://img.shields.io/badge/-New-green](https://img.shields.io/badge/-New-green)
 
-Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
-More about operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) used in the function.
+Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
 ```typescript
 const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ npm i --save @angular-package/type
 
 ## Callback
 
+![update][update]
+
 Default function to handle `callback`.
 
 ```typescript
@@ -209,9 +211,9 @@ The **return value** is a `boolean` type result from the check.
 Custom function to handle `callback`.
 
 ```typescript
-const customCallback: ResultCallback = (result: boolean): boolean => {
+const customCallback: ResultCallback = (result: boolean, value: any): boolean => {
   if (result === false) {
-    throw new Error('error');
+    throw new Error(`${value} must be a string`);
   }
   return result;
 };
@@ -1708,7 +1710,7 @@ const guardUndefined: GuardUndefined = (value: undefined, callback?: ResultCallb
 | Parameter | Type                                | Description                         |
 | :-------- | :---------------------------------: | :---------------------------------- |
 | value     | `undefined`                         | A `undefined` type `value` to guard |
-| callback  | [`ResultCallback`][resultcallback] | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+| callback  | [`ResultCallback`][resultcallback]  | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is `undefined`.
 
@@ -2007,7 +2009,7 @@ type Primitives = 'bigint' | 'boolean' | 'null' | 'number' | 'symbol' | 'string'
 ### ResultCallback
 
 ```typescript
-type ResultCallback = (result: boolean) => boolean;
+type ResultCallback = <Obj>(result: boolean, value?: any) => boolean;
 ```
 
 ### Type

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ import { Constructor, CycleHook, Func, Key, Primitive, Primitives, ResultCallbac
     * a `number` with [`isNumber()`](#isnumber).
     * an `object` type and instance of [`Number`][Number] and [`Object`][object] with [`isNumberObject()`](#isnumberobject).
     * a `number` type and **not** instance of [`Number`][Number] and [`Object`][object] with [`isNumberType()`](#isnumbertype).
-    * a generic type `object` with [`isObject()`](#isobject).
+    * ![update][update] a generic type `object` with [`isObject()`](#isobject).
     * an `object` with its own specified [`Key`][key] with [`isObjectKey()`](#isobjectkey).
-    * an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
+    * ![new][new] an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
     * a one of the primitive `boolean`, `bigint`, `number`, `string` with [`isPrimitive()`](#isPrimitive).
     * a `string` with [`isString()`](#isstring).
     * an `object` type and instance of [`String`][string] and [`Object`][object] with [`isStringObject()`](#isstringobject).

--- a/README.md
+++ b/README.md
@@ -1355,12 +1355,12 @@ function configFunction(value: string): string {
   return '';
 }
 
-// Cause typescript return `boolean` this will generate an type error
+// Cause typescript returns `boolean` this will generate a type error
 if (is.not.undefined(config.a)) {
   configFunction(config.a);
 }
 
-// Cause typescript return `value is boolean` this will not generate an error
+// Cause typescript return `value is boolean` will not generate an error.
 if (!is.undefined(config.a)) {
   configFunction(config.a);
 }

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -740,6 +740,8 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
+![update][update]
+
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
 ```typescript
@@ -987,6 +989,8 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 ----
 
 ### isObjectKeyIn
+
+![https://img.shields.io/badge/-New-green](https://img.shields.io/badge/-New-green)
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
 More about operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) used in the function.
@@ -2081,7 +2085,8 @@ MIT © angular-package ([license](https://github.com/angular-package/type/blob/m
 [symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 [symbolconstructor]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
 
-[new]: https://img.shields.io/badge/-new-red
+[new]: https://img.shields.io/badge/-new-green
+[update]: https://img.shields.io/badge/-update-red
 
 [type-npm-svg]: https://badge.fury.io/js/%40angular-package%2Ftype.svg
 [type-npm-badge]: https://badge.fury.io/js/%40angular-package%2Ftype

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -445,7 +445,7 @@ isBooleanType(BOOLEAN_INSTANCE); // false
 
 ### isDefined
 
-Use `isDefined()` or `is.defined()` to check if an **unknown** `value` is NOT an `undefined` type and is NOT equal to `undefined`.
+Use `isDefined()` or `is.defined()` to check if an **unknown** `value` is **not** an `undefined` type and is **not** equal to `undefined`.
 
 ```typescript
 const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
@@ -743,6 +743,8 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 ### isObject
 
 ![update][update]
+
+* Removed `key` parameter. Use [`isObjectKeyIn`](#isobjectkin) instead.
 
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -111,9 +111,9 @@ import { Constructor, CycleHook, Func, Key, Primitive, Primitives, ResultCallbac
     * a `number` with [`isNumber()`](#isnumber).
     * an `object` type and instance of [`Number`][Number] and [`Object`][object] with [`isNumberObject()`](#isnumberobject).
     * a `number` type and **not** instance of [`Number`][Number] and [`Object`][object] with [`isNumberType()`](#isnumbertype).
-    * ![update][update] a generic type `object` with [`isObject()`](#isobject).
+    * a generic type `object` with [`isObject()`](#isobject).
     * an `object` with its own specified [`Key`][key] with [`isObjectKey()`](#isobjectkey).
-    * ![new][new] an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
+    * an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
     * a one of the primitive `boolean`, `bigint`, `number`, `string` with [`isPrimitive()`](#isPrimitive).
     * a `string` with [`isString()`](#isstring).
     * an `object` type and instance of [`String`][string] and [`Object`][object] with [`isStringObject()`](#isstringobject).

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -59,6 +59,7 @@ import {
   isNumberType,
   isObject,
   isObjectKey,
+  isObjectKeyIn,
   isPrimitive,
   isString,
   isStringObject,
@@ -112,6 +113,7 @@ import { Constructor, CycleHook, Func, Key, Primitive, Primitives, ResultCallbac
     * a `number` type and **not** instance of [`Number`][Number] and [`Object`][object] with [`isNumberType()`](#isnumbertype).
     * a generic type `object` with [`isObject()`](#isobject).
     * an `object` with its own specified [`Key`][key] with [`isObjectKey()`](#isobjectkey).
+    * an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
     * a one of the primitive `boolean`, `bigint`, `number`, `string` with [`isPrimitive()`](#isPrimitive).
     * a `string` with [`isString()`](#isstring).
     * an `object` type and instance of [`String`][string] and [`Object`][object] with [`isStringObject()`](#isstringobject).
@@ -194,8 +196,15 @@ npm i --save @angular-package/type
 Default function to handle `callback`.
 
 ```typescript
-const resultCallback: ResultCallback = (result: boolean): boolean => result;
+const resultCallback: ResultCallback = (result: boolean, value?: any): boolean => result;
 ```
+
+| Parameter | Type      | Description                             |
+| :-------- | :-------: | :-------------------------------------- |
+| result    | `boolean` | A `boolean` type value from the result of the check   |
+| value     | `any`     | Any type value from the check |
+
+The **return value** is a `boolean` type result from the check.
 
 Custom function to handle `callback`.
 
@@ -258,7 +267,7 @@ const is: Is = {
   defined: isDefined,
   function: isFunction,
   instance: isInstance,
-  key: iskey,
+  key: isKey,
   not: isNot,
   null: isNull,
   number: isNumber,
@@ -288,7 +297,8 @@ const isArray: IsArray = <Type>(value: any, callback: ResultCallback = resultCal
     typeOf(value) === 'array' &&
     Array.isArray(value) === true &&
     value instanceof Array === true &&
-    typeof value === 'object'
+    typeof value === 'object',
+    value
   );
 ```
 
@@ -318,7 +328,7 @@ Use `isBigInt()` or `is.bigint()` to check if **any** `value` is a `bigint` type
 
 ```typescript
 const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallback): value is bigint =>
-  callback(typeOf(value) === 'bigint' && typeof value === 'bigint');
+  callback(typeOf(value) === 'bigint' && typeof value === 'bigint', value);
 ```
 
 | Parameter | Type  | Description |
@@ -347,7 +357,7 @@ Use `isBoolean()` or `is.boolean()` to check if **any** `value` is a `boolean` t
 
 ```typescript
 const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallback): value is boolean =>
-  callback(typeOf(value) === 'boolean' && (isBooleanType(value) || isBooleanObject(value)));
+  callback(typeOf(value) === 'boolean' && (isBooleanType(value) || isBooleanObject(value)), value);
 ```
 
 | Parameter | Type  | Description          |
@@ -376,7 +386,7 @@ Use `isBooleanObject()` or `is.booleanObject()` to check if **any** `value` is a
 
 ```typescript
 const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback = resultCallback): value is boolean =>
-  callback(typeof value === 'object' && value instanceof Boolean === true && value instanceof Object === true);
+  callback(typeof value === 'object' && value instanceof Boolean === true && value instanceof Object === true, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -407,7 +417,8 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
     value instanceof Boolean === false &&
     value instanceof Object === false &&
     typeof value === 'boolean' &&
-    (value === true || value === false)
+    (value === true || value === false),
+    value
   );
 ```
 
@@ -435,7 +446,7 @@ Use `isDefined()` or `is.defined()` to check if an **unknown** `value` is NOT an
 
 ```typescript
 const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined);
+  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
 ```
 
 | Parameter | Type      | Description                   |
@@ -466,7 +477,8 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
     typeOf(value) === 'function' &&
     typeof value === 'function' &&
     value instanceof Function === true &&
-    value instanceof Object === true
+    value instanceof Object === true,
+    value
   );
 ```
 
@@ -506,7 +518,8 @@ const isInstance: IsInstance = <Obj>(
         isFunction(instance) ?
           value instanceof instance === true
         : false
-      : false
+      : false,
+      value
     );
 ```
 
@@ -541,7 +554,7 @@ Use `isKey()` or `is.key()` to check if **any** `value` is one of the `string`, 
 
 ```typescript
 const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): value is Key =>
-  callback(isString(value) || isNumber(value) || isSymbol(value));
+  callback(isString(value) || isNumber(value) || isSymbol(value), value);
 ```
 
 | Parameter | Type  | Description          |
@@ -577,7 +590,7 @@ Use `isNull()` or `is.null()` to check if **any** `value` is an `object` type an
 
 ```typescript
 const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): value is null =>
-  callback(typeOf(value) === 'null' && typeof value === 'object' && value === null);
+  callback(typeOf(value) === 'null' && typeof value === 'object' && value === null, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -612,7 +625,7 @@ Use `isNumber()` or `is.number()` to check if **any** `value` is a `number` type
 
 ```typescript
 const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(typeOf(value) === 'number' && isFinite(value) === true && (isNumberType(value) || isNumberObject(value)));
+  callback(typeOf(value) === 'number' && isFinite(value) === true && (isNumberType(value) || isNumberObject(value)), value);
 ```
 
 | Parameter | Type  | Description          |
@@ -632,7 +645,7 @@ Use `isNumberObject()` or `is.numberObject()` to check if **any** `value` is an 
 
 ```typescript
 const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(typeof value === 'object' && value instanceof Number === true && value instanceof Object === true);
+  callback(typeof value === 'object' && value instanceof Number === true && value instanceof Object === true, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -681,7 +694,7 @@ Use `isNumberType()` or `is.numberType()` to check if **any** `value` is a `numb
 
 ```typescript
 const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(value instanceof Number === false && value instanceof Object === false && typeof value === 'number');
+  callback(value instanceof Number === false && value instanceof Object === false && typeof value === 'number', value);
 ```
 
 | Parameter | Type  | Description          |
@@ -726,21 +739,17 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
-Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance with the possibility of containing the `key`.
+Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
 ```typescript
-const isObject: IsObject = <Obj = object>(value: any, key?: Key): value is Obj =>
-  (typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true)
-    ? isKey(key)
-      ? key in value
-    : true
-  : false;
+const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback = resultCallback): value is Obj =>
+  callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);
 ```
 
 | Parameter | Type          | Description |
 | :-------- | :-----------: | :---------- |
 | value     | `any`         | Any `value` to check |
-| key?      | [`Key`][key] | Property name to find in the `value` |
+| callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object`.
 
@@ -811,7 +820,6 @@ const OBJECT_ONE: ObjectOne = {
 };
 
 isObject(OBJECT_ONE); // true
-isObject(OBJECT_ONE, 'key as string'); // true
 isObject(OBJECT_ONE, STRING); // true
 isObject(OBJECT_ONE, STRING_NEW_INSTANCE); // true
 isObject(OBJECT_ONE, 1030405027); // true
@@ -841,7 +849,8 @@ const isObjectKey: IsObjectKey = <Type extends object>(
       : isKey(key) ?
           ({}).hasOwnProperty.call(value, key)
         : false
-    : false
+    : false,
+    value
   );
 ```
 
@@ -852,6 +861,38 @@ const isObjectKey: IsObjectKey = <Type extends object>(
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys.
+
+----
+
+### isObjectKeyIn
+
+Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
+
+```typescript
+const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(
+  value: any,
+  key: Key | Key[],
+  callback: ResultCallback = resultCallback
+): value is Type =>
+  callback(
+    isObject<Type>(value) ?
+      isArray(key) ?
+        key.every(k => isKey(k) ? k in value : false)
+      : isKey(key) ?
+          key in value
+        : false
+    : false,
+    value
+  );
+```
+
+| Parameter | Type                             | Description                                           |
+| :-------- | :------------------------------: | :---------------------------------------------------- |
+| value     | `any`                            | Any `value` to check if it contains a specified `key` |
+| key       | [`Key`][key] \| [`Key`][key][] | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+
+The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys.
 
 ----
 
@@ -898,7 +939,7 @@ Use `isString()` or `is.string()` to check if **any** `value` is a `string` type
 
 ```typescript
 const isString: IsString = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(typeOf(value) === 'string' && (isStringType(value) || isStringObject(value)));
+  callback(typeOf(value) === 'string' && (isStringType(value) || isStringObject(value)), value);
 ```
 
 | Parameter |       Type                          | Description          |
@@ -916,7 +957,7 @@ Use `isStringObject()` or `is.stringObject()` to check if **any** `value` is an 
 
 ```typescript
 const isStringObject: IsStringObject = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(value instanceof Object === true && value instanceof String === true && typeof value === 'object');
+  callback(value instanceof Object === true && value instanceof String === true && typeof value === 'object', value);
 ```
 
 | Parameter |       Type                          | Description          |
@@ -934,7 +975,7 @@ Use `isStringType()` or `is.stringType()` to check if **any** `value` is a `stri
 
 ```typescript
 const isStringType: IsStringType = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string');
+  callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string', value);
 ```
 
 | Parameter | Type                                                                    | Description          |
@@ -952,7 +993,7 @@ Use `isSymbol()` or `is.symbol()` to check if **any** `value` is a `symbol` type
 
 ```typescript
 const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallback): value is symbol =>
-  callback(typeOf(value) === 'symbol' && typeof value === 'symbol');
+  callback(typeOf(value) === 'symbol' && typeof value === 'symbol', value);
 ```
 
 | Parameter | Type  | Description          |
@@ -1013,7 +1054,7 @@ Use `isUndefined()` or `is.undefined()` to check if **any** `value` is an `undef
 
 ```typescript
 const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultCallback): value is undefined =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined);
+  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);
 ```
 
 | Parameter | Type  | Description          |
@@ -1054,7 +1095,8 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
     typeof value !== 'boolean' &&
     value instanceof Boolean === false &&
     value !== true &&
-    value !== false
+    value !== false,
+    value
   );
 ```
 
@@ -1073,7 +1115,7 @@ Use `isNotDefined()` or `is.not.defined()` to check if an **unknown** `value` is
 
 ```typescript
 const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined);
+  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1091,7 +1133,7 @@ Use `isNotFunction()` or `is.not.function()` to check if an **unknown** `value` 
 
 ```typescript
 const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false);
+  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1109,7 +1151,7 @@ Use `isNotNull()` or `is.not.null()` to check if an **unknown** `value` is **not
 
 ```typescript
 const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'null' && value !== null);
+  callback(typeOf(value) !== 'null' && value !== null, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1130,7 +1172,8 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
   callback(
     typeOf(value) !== 'number' &&
     typeof value !== 'number' &&
-    value instanceof Number === false
+    value instanceof Number === false,
+    value
   );
 ```
 
@@ -1149,7 +1192,7 @@ Use `isNotString()` or `is.not.string()` to check if an **unknown** `value` is *
 
 ```typescript
 const isNotString: IsNotString = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false);
+  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false, value);
 ```
 
 | Parameter | Type      | Description                 |
@@ -1167,7 +1210,7 @@ Use `isNotUndefined()` or `is.not.undefined()` to check if an **unknown** `value
 
 ```typescript
 const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined);
+  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
 ```
 
 | Parameter | Type      | Description                 |

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -68,7 +68,9 @@ import {
   isType,
   isUndefined
 } from '@angular-package/type';
+```
 
+```typescript
 // `are` prefix functions.
 import {
   areString

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -764,57 +764,6 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ```typescript
 // Example usage
-const SYMBOL_NUMBER: unique symbol = Symbol(NUMBER);
-const SYMBOL_STRING: unique symbol = Symbol(STRING);
-
-/**
- * typeof === 'number'
- * instanceof Function === false
- * instanceof Number === false
- * instanceof Object === false
- */
-const NUMBER: any = 10304050;
-
-/**
- * typeof === 'number'
- * instanceof Function === false
- * instanceof Number === false
- * instanceof Object === false
- */
-const NUMBER_INSTANCE: any = Number(NUMBER);
-
-/**
- * typeof === 'number'
- * instanceof Function === false
- * instanceof Number === true
- * instanceof Object === true
- */
-const NUMBER_NEW_INSTANCE: any = new Number(NUMBER);
-
-/**
- * typeof === 'string'
- * instanceof Function === false
- * instanceof Object === false
- * instanceof String === false
- */
-const STRING: any = '!@#$%^&*()abcdefghijklmnoprstuwyz';
-
-/**
- * typeof === 'string'
- * instanceof Function === false
- * instanceof Object === false
- * instanceof String === false
- */
-const STRING_INSTANCE: any = String(STRING);
-
-/**
- * typeof === 'string'
- * instanceof Function === false
- * instanceof Object === true
- * instanceof String === true
- */
-const STRING_NEW_INSTANCE: any = new String(STRING);
-
 const OBJECT_ONE: ObjectOne = {
   'key as string': true,
   1030405027: 'key is number',
@@ -827,13 +776,6 @@ const OBJECT_ONE: ObjectOne = {
 };
 
 isObject(OBJECT_ONE); // true
-isObject(OBJECT_ONE, STRING); // true
-isObject(OBJECT_ONE, STRING_NEW_INSTANCE); // true
-isObject(OBJECT_ONE, 1030405027); // true
-isObject(OBJECT_ONE, NUMBER); // true
-isObject(OBJECT_ONE, NUMBER_NEW_INSTANCE); // true
-isObject(OBJECT_ONE, SYMBOL_NUMBER); // true
-isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ```
 
@@ -982,7 +924,7 @@ export class Class {
  */
 export const CLASS = new Class();
 
-// One of the differences between `in` operator and the `hasOwnProperty()` method is that it doesn't find a getter key
+// One of the differences between the `in` operator and the `hasOwnProperty()` method is that it doesn't find a getter key
 isObjectKey(CLASS, SYMBOL_NUMBER); // false
 isObjectKey(CLASS, SYMBOL_STRING); // false
 isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
@@ -993,7 +935,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ### isObjectKeyIn
 
-![https://img.shields.io/badge/-New-green](https://img.shields.io/badge/-New-green)
+![new][new]
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
@@ -1123,7 +1065,7 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | Parameter |       Type                          | Description          |
 | :-------- | :---------------------------------: | :------------------- |
 | value     | `any`                               | Any `value` to check |
-| callback  | [`ResultCallback`][resultcallback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+| callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is a `string`.
 
@@ -1156,9 +1098,9 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
   callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string', value);
 ```
 
-| Parameter | Type                                                                    | Description          |
-| :-------- | :---------------------------------------------------------------------: | :------------------- |
-| value     | `any`                                                                   | Any `value` to check |
+| Parameter | Type                                                            | Description          |
+| :-------- | :-------------------------------------------------------------: | :------------------- |
+| value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is a `string`.
@@ -1397,6 +1339,33 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The return value is a `boolean` indicating whether or not the `value` is not `undefined`.
+
+```typescript
+// Example usage with the problem
+interface Config {
+  a?: string;
+  b?: string;
+}
+let config: Config = {
+  a: 'x',
+  b: 'y'
+};
+
+function configFunction(value: string): string {
+  return '';
+}
+
+// Cause typescript return `boolean` this will generate an type error
+if (is.not.undefined(config.a)) {
+  configFunction(config.a);
+}
+
+// Cause typescript return `value is boolean` this will not generate an error
+if (!is.undefined(config.a)) {
+  configFunction(config.a);
+}
+
+```
 
 ----
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -275,6 +275,7 @@ const is: Is = {
   numberType: isNumberType,
   object: isObject,
   objectKey: isObjectKey,
+  objectKeyIn: isObjectKeyIn,
   primitive: isPrimitive,
   string: isString,
   stringObject: isStringObject,
@@ -834,7 +835,8 @@ isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ### isObjectKey
 
-Use `isObject()` or `is.object()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
+Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
+More about [`hasOwnProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) method used in the function.
 
 ```typescript
 const isObjectKey: IsObjectKey = <Type extends object>(
@@ -862,11 +864,132 @@ const isObjectKey: IsObjectKey = <Type extends object>(
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys.
 
+```typescript
+// Example usage
+const SYMBOL_NUMBER: unique symbol = Symbol(NUMBER);
+const SYMBOL_STRING: unique symbol = Symbol(STRING);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER: any = 10304050;
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER_INSTANCE: any = Number(NUMBER);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === true
+ * instanceof Object === true
+ */
+const NUMBER_NEW_INSTANCE: any = new Number(NUMBER);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING: any = '!@#$%^&*()abcdefghijklmnoprstuwyz';
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING_INSTANCE: any = String(STRING);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === true
+ * instanceof String === true
+ */
+const STRING_NEW_INSTANCE: any = new String(STRING);
+
+const OBJECT_ONE: ObjectOne = {
+  'key as string': true,
+  1030405027: 'key is number',
+  5: 'key is also number',
+  [NUMBER]: 'key is number',
+  [string]: 'key is string',
+  [SYMBOL_NUMBER]: 'key is symbol number',
+  [SYMBOL_STRING]: 6,
+  x: 3000
+};
+
+isObjectKey(OBJECT_ONE, STRING); // true
+isObjectKey(OBJECT_ONE, STRING_NEW_INSTANCE); // true
+isObjectKey(OBJECT_ONE, 1030405027); // true
+isObjectKey(OBJECT_ONE, NUMBER); // true
+isObjectKey(OBJECT_ONE, NUMBER_NEW_INSTANCE); // true
+isObjectKey(OBJECT_ONE, SYMBOL_NUMBER); // true
+isObjectKey(OBJECT_ONE, SYMBOL_STRING); // true
+
+/**
+ * typeof === 'function'
+ * instanceof Class === false
+ * instanceof Function === true
+ * instanceof Object === true
+ */
+export class Class {
+
+  1030405027 = 'my new number';
+  5 = 'my number';
+
+  firstName = 'My name';
+  surname = 'Surname';
+
+  x = NUMBER;
+  y = STRING;
+
+  get [NUMBER](): number {
+    return this.x;
+  }
+  get [STRING](): string {
+    return this.y;
+  }
+
+  get [SYMBOL_NUMBER](): number {
+    return this.x;
+  }
+
+  get [SYMBOL_STRING](): string {
+    return this.y;
+  }
+}
+
+/**
+ * typeof === 'object'
+ * instanceof Class === true
+ * instanceof Function === false
+ * instanceof Object === true
+ */
+export const CLASS = new Class();
+
+// One of the differences between `in` operator and the `hasOwnProperty()` method is that it doesn't find a getter key
+isObjectKey(CLASS, SYMBOL_NUMBER); // false
+isObjectKey(CLASS, SYMBOL_STRING); // false
+isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
+ 
+```
+
 ----
 
 ### isObjectKeyIn
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
+More about operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) used in the function.
 
 ```typescript
 const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(
@@ -893,6 +1016,55 @@ const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys.
+
+```typescript
+/**
+ * typeof === 'function'
+ * instanceof Class === false
+ * instanceof Function === true
+ * instanceof Object === true
+ */
+export class Class {
+
+  1030405027 = 'my new number';
+  5 = 'my number';
+
+  firstName = 'My name';
+  surname = 'Surname';
+
+  x = NUMBER;
+  y = STRING;
+
+  get [NUMBER](): number {
+    return this.x;
+  }
+  get [STRING](): string {
+    return this.y;
+  }
+
+  get [SYMBOL_NUMBER](): number {
+    return this.x;
+  }
+
+  get [SYMBOL_STRING](): string {
+    return this.y;
+  }
+}
+
+/**
+ * typeof === 'object'
+ * instanceof Class === true
+ * instanceof Function === false
+ * instanceof Object === true
+ */
+export const CLASS = new Class();
+
+// One of the differences between `in` operator and the `hasOwnProperty()` method is that it finds a getter key
+isObjectKeyIn(OBJECT_ONE, SYMBOL_NUMBER); // true
+isObjectKeyIn(OBJECT_ONE, SYMBOL_STRING); // true
+isObjectKeyIn(OBJECT_ONE, [SYMBOL_NUMBER, SYMBOL_STRING]); // true
+
+```
 
 ----
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -42,7 +42,7 @@ import {
 ```
 
 ```typescript
-// Check `is` prefix functions.
+// `is` prefix functions.
 import {
   isArray,
   isBigInt,
@@ -68,12 +68,15 @@ import {
   isType,
   isUndefined
 } from '@angular-package/type';
-// Check `are` prefix functions.
-import { areString } from '@angular-package/type';
+
+// `are` prefix functions.
+import {
+  areString
+} from '@angular-package/type';
 ```
 
 ```typescript
-// Check `isNot` prefix functions.
+// `isNot` prefix functions.
 import {
   isNotBoolean,
   isNotDefined,

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -742,21 +742,21 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
-![update][update]
-
-* Removed `key` parameter. Use [`isObjectKeyIn`](#isobjectkin) instead.
-
-Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
+Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance with the possibility of containing the `key`.
 
 ```typescript
-const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback = resultCallback): value is Obj =>
-  callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);
+const isObject: IsObject = <Obj = object>(value: any, key?: Key): value is Obj =>
+  (typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true)
+    ? isKey(key)
+      ? key in value
+    : true
+  : false;
 ```
 
 | Parameter | Type          | Description |
 | :-------- | :-----------: | :---------- |
 | value     | `any`         | Any `value` to check |
-| callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+| key?      | [`Key`][key] | Property name to find in the `value` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object`.
 
@@ -764,6 +764,57 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ```typescript
 // Example usage
+const SYMBOL_NUMBER: unique symbol = Symbol(NUMBER);
+const SYMBOL_STRING: unique symbol = Symbol(STRING);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER: any = 10304050;
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === false
+ * instanceof Object === false
+ */
+const NUMBER_INSTANCE: any = Number(NUMBER);
+
+/**
+ * typeof === 'number'
+ * instanceof Function === false
+ * instanceof Number === true
+ * instanceof Object === true
+ */
+const NUMBER_NEW_INSTANCE: any = new Number(NUMBER);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING: any = '!@#$%^&*()abcdefghijklmnoprstuwyz';
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === false
+ * instanceof String === false
+ */
+const STRING_INSTANCE: any = String(STRING);
+
+/**
+ * typeof === 'string'
+ * instanceof Function === false
+ * instanceof Object === true
+ * instanceof String === true
+ */
+const STRING_NEW_INSTANCE: any = new String(STRING);
+
 const OBJECT_ONE: ObjectOne = {
   'key as string': true,
   1030405027: 'key is number',
@@ -776,6 +827,14 @@ const OBJECT_ONE: ObjectOne = {
 };
 
 isObject(OBJECT_ONE); // true
+isObject(OBJECT_ONE, 'key as string'); // true
+isObject(OBJECT_ONE, STRING); // true
+isObject(OBJECT_ONE, STRING_NEW_INSTANCE); // true
+isObject(OBJECT_ONE, 1030405027); // true
+isObject(OBJECT_ONE, NUMBER); // true
+isObject(OBJECT_ONE, NUMBER_NEW_INSTANCE); // true
+isObject(OBJECT_ONE, SYMBOL_NUMBER); // true
+isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ```
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -837,8 +837,7 @@ isObject(OBJECT_ONE, SYMBOL_STRING); // true
 
 ### isObjectKey
 
-Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
-More about [`hasOwnProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) method used in the function.
+Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key]. The Function uses [`hasOwnProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) method to find the key.
 
 ```typescript
 const isObjectKey: IsObjectKey = <Type extends object>(
@@ -992,8 +991,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ![https://img.shields.io/badge/-New-green](https://img.shields.io/badge/-New-green)
 
-Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator.
-More about operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) used in the function.
+Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
 ```typescript
 const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -193,6 +193,8 @@ npm i --save @angular-package/type
 
 ## Callback
 
+![update][update]
+
 Default function to handle `callback`.
 
 ```typescript
@@ -209,9 +211,9 @@ The **return value** is a `boolean` type result from the check.
 Custom function to handle `callback`.
 
 ```typescript
-const customCallback: ResultCallback = (result: boolean): boolean => {
+const customCallback: ResultCallback = (result: boolean, value: any): boolean => {
   if (result === false) {
-    throw new Error('error');
+    throw new Error(`${value} must be a string`);
   }
   return result;
 };
@@ -1708,7 +1710,7 @@ const guardUndefined: GuardUndefined = (value: undefined, callback?: ResultCallb
 | Parameter | Type                                | Description                         |
 | :-------- | :---------------------------------: | :---------------------------------- |
 | value     | `undefined`                         | A `undefined` type `value` to guard |
-| callback  | [`ResultCallback`][resultcallback] | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
+| callback  | [`ResultCallback`][resultcallback]  | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is `undefined`.
 
@@ -2007,7 +2009,7 @@ type Primitives = 'bigint' | 'boolean' | 'null' | 'number' | 'symbol' | 'string'
 ### ResultCallback
 
 ```typescript
-type ResultCallback = (result: boolean) => boolean;
+type ResultCallback = <Obj>(result: boolean, value?: any) => boolean;
 ```
 
 ### Type

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -111,9 +111,9 @@ import { Constructor, CycleHook, Func, Key, Primitive, Primitives, ResultCallbac
     * a `number` with [`isNumber()`](#isnumber).
     * an `object` type and instance of [`Number`][Number] and [`Object`][object] with [`isNumberObject()`](#isnumberobject).
     * a `number` type and **not** instance of [`Number`][Number] and [`Object`][object] with [`isNumberType()`](#isnumbertype).
-    * a generic type `object` with [`isObject()`](#isobject).
+    * ![update][update] a generic type `object` with [`isObject()`](#isobject).
     * an `object` with its own specified [`Key`][key] with [`isObjectKey()`](#isobjectkey).
-    * an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
+    * ![new][new] an `object` with the [`Key`][key] by using the `in` operator with [`isObjectKeyIn()`](#isobjectkeyin).
     * a one of the primitive `boolean`, `bigint`, `number`, `string` with [`isPrimitive()`](#isPrimitive).
     * a `string` with [`isString()`](#isstring).
     * an `object` type and instance of [`String`][string] and [`Object`][object] with [`isStringObject()`](#isstringobject).

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -1355,12 +1355,12 @@ function configFunction(value: string): string {
   return '';
 }
 
-// Cause typescript return `boolean` this will generate an type error
+// Cause typescript returns `boolean` this will generate a type error
 if (is.not.undefined(config.a)) {
   configFunction(config.a);
 }
 
-// Cause typescript return `value is boolean` this will not generate an error
+// Cause typescript return `value is boolean` will not generate an error.
 if (!is.undefined(config.a)) {
   configFunction(config.a);
 }

--- a/packages/type/package-lock.json
+++ b/packages/type/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@angular-package/type",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@angular-package/type",
-      "version": "3.2.4",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-package/type",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "description": "Common types, type guards and type checkers.",
   "author": "Angular Package <angular-package@wvvw.dev> (https://wvvw.dev)",
   "homepage": "https://github.com/angular-package/type#readme",

--- a/packages/type/src/is/index.ts
+++ b/packages/type/src/is/index.ts
@@ -14,6 +14,7 @@ export { isNumberObject } from './lib/is-number-object.func';
 export { isNumberType } from './lib/is-number-type.func';
 export { isObject } from './lib/is-object.func';
 export { isObjectKey } from './lib/is-object-key.func';
+export { isObjectKeyIn } from './lib/is-object-key-in.func';
 export { isPrimitive } from './lib/is-primitive.func';
 export { isString } from './lib/is-string.func';
 export { isStringObject } from './lib/is-string-object.func';

--- a/packages/type/src/is/interface/is.interface.ts
+++ b/packages/type/src/is/interface/is.interface.ts
@@ -2,6 +2,7 @@ import { IsArray } from '../type/is-array.type';
 import { IsBigInt } from '../type/is-big-int.type';
 import { IsBoolean } from '../type/is-boolean.type';
 import { IsBooleanObject } from '../type/is-boolean-object.type';
+import { IsBooleanType } from '../type/is-boolean-type.type';
 import { IsDefined } from '../type/is-defined.type';
 import { IsFunction } from '../type/is-function.type';
 import { IsInstance } from '../type/is-instance.type';
@@ -9,8 +10,11 @@ import { IsKey } from '../type/is-key.type';
 import { IsNot } from '../not/interface/is-not.interface';
 import { IsNull } from '../type/is-null.type';
 import { IsNumber } from '../type/is-number.type';
+import { IsNumberObject } from '../type/is-number-object.type';
+import { IsNumberType } from '../type/is-number-type.type';
 import { IsObject } from '../type/is-object.type';
 import { IsObjectKey } from '../type/is-object-key.type';
+import { IsObjectKeyIn } from '../type/is-object-key-in.type';
 import { IsPrimitive } from '../type/is-primitive.type';
 import { IsString } from '../type/is-string.type';
 import { IsStringObject } from '../type/is-string-object.type';
@@ -18,10 +22,6 @@ import { IsStringType } from '../type/is-string-type.type';
 import { IsSymbol } from '../type/is-symbol.type';
 import { IsType } from '../type/is-type.type';
 import { IsUndefined } from '../type/is-undefined.type';
-import { IsBooleanType } from '../type/is-boolean-type.type';
-import { IsNumberObject } from '../type/is-number-object.type';
-import { IsNumberType } from '../type/is-number-type.type';
-
 export interface Is {
   array: IsArray;
   bigInt: IsBigInt;
@@ -40,6 +40,7 @@ export interface Is {
   numberType: IsNumberType;
   object: IsObject;
   objectKey: IsObjectKey;
+  objectKeyIn: IsObjectKeyIn;
   primitive: IsPrimitive;
   string: IsString;
   stringObject: IsStringObject;

--- a/packages/type/src/is/lib/is-array.func.ts
+++ b/packages/type/src/is/lib/is-array.func.ts
@@ -16,5 +16,6 @@ export const isArray: IsArray = <Type>(value: any, callback: ResultCallback = re
     typeOf(value) === 'array' &&
     Array.isArray(value) === true &&
     value instanceof Array === true &&
-    typeof value === 'object'
+    typeof value === 'object',
+    value
   );

--- a/packages/type/src/is/lib/is-big-int.func.ts
+++ b/packages/type/src/is/lib/is-big-int.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `bigint`.
  */
 export const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallback): value is bigint =>
-  callback(typeOf(value) === 'bigint' && typeof value === 'bigint');
+  callback(typeOf(value) === 'bigint' && typeof value === 'bigint', value);

--- a/packages/type/src/is/lib/is-boolean-object.func.ts
+++ b/packages/type/src/is/lib/is-boolean-object.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `Boolean` instance.
  */
 export const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback = resultCallback): value is boolean =>
-  callback(typeof value === 'object' && value instanceof Boolean === true && value instanceof Object === true);
+  callback(typeof value === 'object' && value instanceof Boolean === true && value instanceof Object === true, value);

--- a/packages/type/src/is/lib/is-boolean-type.func.ts
+++ b/packages/type/src/is/lib/is-boolean-type.func.ts
@@ -16,5 +16,6 @@ export const isBooleanType: IsBooleanType = (value: any, callback: ResultCallbac
     value instanceof Boolean === false &&
     value instanceof Object === false &&
     typeof value === 'boolean' &&
-    (value === true || value === false)
+    (value === true || value === false),
+    value
   );

--- a/packages/type/src/is/lib/is-boolean.func.ts
+++ b/packages/type/src/is/lib/is-boolean.func.ts
@@ -14,4 +14,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `boolean`.
  */
 export const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallback): value is boolean =>
-  callback(typeOf(value) === 'boolean' && (isBooleanType(value) || isBooleanObject(value)));
+  callback(typeOf(value) === 'boolean' && (isBooleanType(value) || isBooleanObject(value)), value);

--- a/packages/type/src/is/lib/is-defined.func.ts
+++ b/packages/type/src/is/lib/is-defined.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is defined, not `undefined`.
  */
 export const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined);
+  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);

--- a/packages/type/src/is/lib/is-function.func.ts
+++ b/packages/type/src/is/lib/is-function.func.ts
@@ -17,5 +17,6 @@ export const isFunction: IsFunction = (value: any, callback: ResultCallback = re
     typeOf(value) === 'function' &&
     typeof value === 'function' &&
     value instanceof Function === true &&
-    value instanceof Object === true
+    value instanceof Object === true,
+    value
   );

--- a/packages/type/src/is/lib/is-instance.func.ts
+++ b/packages/type/src/is/lib/is-instance.func.ts
@@ -24,5 +24,6 @@ export const isInstance: IsInstance = <Obj>(
         isFunction(instance) ?
           value instanceof instance === true
         : false
-      : false
+      : false,
+      value
     );

--- a/packages/type/src/is/lib/is-key.func.ts
+++ b/packages/type/src/is/lib/is-key.func.ts
@@ -15,4 +15,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `Key`.
  */
 export const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): value is Key =>
-  callback(isString(value) || isNumber(value) || isSymbol(value));
+  callback(isString(value) || isNumber(value) || isSymbol(value), value);

--- a/packages/type/src/is/lib/is-null.func.ts
+++ b/packages/type/src/is/lib/is-null.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is `null`.
  */
 export const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): value is null =>
-  callback(typeOf(value) === 'null' && typeof value === 'object' && value === null);
+  callback(typeOf(value) === 'null' && typeof value === 'object' && value === null, value);

--- a/packages/type/src/is/lib/is-number-object.func.ts
+++ b/packages/type/src/is/lib/is-number-object.func.ts
@@ -11,4 +11,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `Number` instance.
  */
 export const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(typeof value === 'object' && value instanceof Number === true && value instanceof Object === true);
+  callback(typeof value === 'object' && value instanceof Number === true && value instanceof Object === true, value);

--- a/packages/type/src/is/lib/is-number-type.func.ts
+++ b/packages/type/src/is/lib/is-number-type.func.ts
@@ -11,4 +11,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `number` type.
  */
 export const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(value instanceof Number === false && value instanceof Object === false && typeof value === 'number');
+  callback(value instanceof Number === false && value instanceof Object === false && typeof value === 'number', value);

--- a/packages/type/src/is/lib/is-number.func.ts
+++ b/packages/type/src/is/lib/is-number.func.ts
@@ -14,4 +14,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `number`.
  */
 export const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallback): value is number =>
-  callback(typeOf(value) === 'number' && isFinite(value) === true && (isNumberType(value) || isNumberObject(value)));
+  callback(typeOf(value) === 'number' && isFinite(value) === true && (isNumberType(value) || isNumberObject(value)), value);

--- a/packages/type/src/is/lib/is-object-key-in.func.ts
+++ b/packages/type/src/is/lib/is-object-key-in.func.ts
@@ -1,0 +1,32 @@
+// Function.
+import { isArray } from './is-array.func';
+import { isKey } from './is-key.func';
+import { isObject } from './is-object.func';
+import { resultCallback } from '../../lib/result-callback.func';
+// Type.
+import { IsObjectKeyIn } from '../type/is-object-key-in.type';
+import { Key } from '../../type/key.type';
+import { ResultCallback } from '../../type/result-callback.type';
+/**
+ * Checks if any `value` is an `Object` with the `key` of the `Key` type by using the `in` operator.
+ * @param value Any `value` to check if it contains a specified `key`.
+ * @param key A `Key` type or an array of `Key` type to check in the `value`.
+ * @param callback `ResultCallback` function to handle result before returns.
+ * @callback `resultCallback`.
+ * @returns A `boolean` indicating whether or not the `value` is an `object` with the keys.
+ */
+export const isObjectKeyIn: IsObjectKeyIn = <Type extends object>(
+  value: any,
+  key: Key | Key[],
+  callback: ResultCallback = resultCallback
+): value is Type =>
+  callback(
+    isObject<Type>(value) ?
+      isArray(key) ?
+        key.every(k => isKey(k) ? k in value : false)
+      : isKey(key) ?
+          key in value
+        : false
+    : false,
+    value
+  );

--- a/packages/type/src/is/lib/is-object-key.func.ts
+++ b/packages/type/src/is/lib/is-object-key.func.ts
@@ -27,5 +27,6 @@ export const isObjectKey: IsObjectKey = <Type extends object>(
       : isKey(key) ?
           ({}).hasOwnProperty.call(value, key)
         : false
-    : false
+    : false,
+    value
   );

--- a/packages/type/src/is/lib/is-object.func.ts
+++ b/packages/type/src/is/lib/is-object.func.ts
@@ -1,15 +1,18 @@
 // Function.
-import { resultCallback } from '../../lib/result-callback.func';
+import { isKey } from './is-key.func';
 import { typeOf } from '../../lib/type-of.func';
 // Type.
 import { IsObject } from '../type/is-object.type';
-import { ResultCallback } from '../../type/result-callback.type';
+import { Key } from '../../type/key.type';
 /**
- * Checks if any `value` is an `object` of a generic `Obj` type and `Object` instance.
+ * Checks if any `value` is an `object` of a generic `Obj` type and `Object` instance with the possibility of containing the `key`.
  * @param value Any `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
- * @callback `resultCallback`.
+ * @param key Property name to find in the `value`.
  * @returns A `boolean` indicating whether or not the `value` is an `object`.
  */
-export const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback = resultCallback): value is Obj =>
-  callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);
+export const isObject: IsObject = <Obj = object>(value: any, key?: Key): value is Obj =>
+  (typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true)
+    ? isKey(key)
+      ? key in value
+    : true
+  : false;

--- a/packages/type/src/is/lib/is-object.func.ts
+++ b/packages/type/src/is/lib/is-object.func.ts
@@ -1,18 +1,15 @@
 // Function.
-import { isKey } from './is-key.func';
+import { resultCallback } from '../../lib/result-callback.func';
 import { typeOf } from '../../lib/type-of.func';
 // Type.
 import { IsObject } from '../type/is-object.type';
-import { Key } from '../../type/key.type';
+import { ResultCallback } from '../../type/result-callback.type';
 /**
- * Checks if any `value` is an `object` of a generic `Obj` type and `Object` instance with the possibility of containing the `key`.
+ * Checks if any `value` is an `object` of a generic `Obj` type and `Object` instance.
  * @param value Any `value` to check.
- * @param key Property name to find in the `value`.
+ * @param callback `ResultCallback` function to handle result before returns.
+ * @callback `resultCallback`.
  * @returns A `boolean` indicating whether or not the `value` is an `object`.
  */
-export const isObject: IsObject = <Obj = object>(value: any, key?: Key): value is Obj =>
-  (typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true)
-    ? isKey(key)
-      ? key in value
-    : true
-  : false;
+export const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback = resultCallback): value is Obj =>
+  callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);

--- a/packages/type/src/is/lib/is-string-gen.func.ts
+++ b/packages/type/src/is/lib/is-string-gen.func.ts
@@ -1,0 +1,13 @@
+
+function* isStringGenerator(value: any): Generator {
+  yield typeOf(value) === 'string';
+  yield isStringType(value);
+  yield isStringObject(value);
+}
+
+function isStringChecks(value: any, callback: any) {
+  const gen: Generator = isStringGenerator(value);
+  for (const val of gen) {
+    callback(gen);
+  }
+}

--- a/packages/type/src/is/lib/is-string-object.func.ts
+++ b/packages/type/src/is/lib/is-string-object.func.ts
@@ -11,4 +11,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `String` instance.
  */
 export const isStringObject: IsStringObject = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(value instanceof Object === true && value instanceof String === true && typeof value === 'object');
+  callback(value instanceof Object === true && value instanceof String === true && typeof value === 'object', value);

--- a/packages/type/src/is/lib/is-string-type.func.ts
+++ b/packages/type/src/is/lib/is-string-type.func.ts
@@ -11,4 +11,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the value is a `string`.
  */
 export const isStringType: IsStringType = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string');
+  callback(value instanceof Object === false && value instanceof String === false && typeof value === 'string', value);

--- a/packages/type/src/is/lib/is-string.func.ts
+++ b/packages/type/src/is/lib/is-string.func.ts
@@ -14,4 +14,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is a `string`.
  */
 export const isString: IsString = (value: any, callback: ResultCallback = resultCallback): value is string =>
-  callback(typeOf(value) === 'string' && (isStringType(value) || isStringObject(value)));
+  callback(typeOf(value) === 'string' && (isStringType(value) || isStringObject(value)), value);

--- a/packages/type/src/is/lib/is-symbol.func.ts
+++ b/packages/type/src/is/lib/is-symbol.func.ts
@@ -7,9 +7,9 @@ import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Checks if any `value` is a `symbol` type.
  * @param value Any `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
+ * @param callback A `ResultCallback` function to handle result before returns.
  * @callback `resultCallback`.
  * @returns A `boolean` indicating whether or not the `value` is a `symbol`.
  */
 export const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallback): value is symbol =>
-  callback(typeOf(value) === 'symbol' && typeof value === 'symbol');
+  callback(typeOf(value) === 'symbol' && typeof value === 'symbol', value);

--- a/packages/type/src/is/lib/is-undefined.func.ts
+++ b/packages/type/src/is/lib/is-undefined.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is `undefined`.
  */
 export const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultCallback): value is undefined =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined);
+  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);

--- a/packages/type/src/is/lib/is.object.ts
+++ b/packages/type/src/is/lib/is.object.ts
@@ -14,6 +14,7 @@ import { isNumberObject } from './is-number-object.func';
 import { isNumberType } from './is-number-type.func';
 import { isObject } from './is-object.func';
 import { isObjectKey } from './is-object-key.func';
+import { isObjectKeyIn } from './is-object-key-in.func';
 import { isPrimitive } from './is-primitive.func';
 import { isString } from './is-string.func';
 import { isStringObject } from './is-string-object.func';
@@ -44,6 +45,7 @@ export const is: Is = {
   numberType: isNumberType,
   object: isObject,
   objectKey: isObjectKey,
+  objectKeyIn: isObjectKeyIn,
   primitive: isPrimitive,
   string: isString,
   stringObject: isStringObject,

--- a/packages/type/src/is/not/lib/is-not-boolean.func.ts
+++ b/packages/type/src/is/not/lib/is-not-boolean.func.ts
@@ -17,5 +17,6 @@ export const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallb
     typeof value !== 'boolean' &&
     value instanceof Boolean === false &&
     value !== true &&
-    value !== false
+    value !== false,
+    value
   );

--- a/packages/type/src/is/not/lib/is-not-defined.func.ts
+++ b/packages/type/src/is/not/lib/is-not-defined.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is not defined.
  */
 export const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined);
+  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);

--- a/packages/type/src/is/not/lib/is-not-function.func.ts
+++ b/packages/type/src/is/not/lib/is-not-function.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is not a `function`.
  */
 export const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false);
+  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false, value);

--- a/packages/type/src/is/not/lib/is-not-null.func.ts
+++ b/packages/type/src/is/not/lib/is-not-null.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is not `null`.
  */
 export const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'null' && value !== null);
+  callback(typeOf(value) !== 'null' && value !== null, value);

--- a/packages/type/src/is/not/lib/is-not-number.func.ts
+++ b/packages/type/src/is/not/lib/is-not-number.func.ts
@@ -16,5 +16,6 @@ export const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = 
   callback(
     typeOf(value) !== 'number' &&
     typeof value !== 'number' &&
-    value instanceof Number === false
+    value instanceof Number === false,
+    value
   );

--- a/packages/type/src/is/not/lib/is-not-string.func.ts
+++ b/packages/type/src/is/not/lib/is-not-string.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is not a `string`.
  */
 export const isNotString: IsNotString = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false);
+  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false, value);

--- a/packages/type/src/is/not/lib/is-not-undefined.func.ts
+++ b/packages/type/src/is/not/lib/is-not-undefined.func.ts
@@ -12,4 +12,4 @@ import { ResultCallback } from '../../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is not `undefined`.
  */
 export const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined);
+  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);

--- a/packages/type/src/is/test/is-object-key-in.spec.ts
+++ b/packages/type/src/is/test/is-object-key-in.spec.ts
@@ -1,0 +1,149 @@
+// Function.
+import { isObjectKeyIn } from '../lib/is-object-key-in.func';
+// Variables.
+import { BIGINT, BIGINT_EXPECTATION, BIGINT_INSTANCE } from './variables/big-int.const';
+import { Class, CLASS } from './variables/class.const';
+import { FALSE, TRUE, TRUE_INSTANCE, FALSE_INSTANCE, FALSE_EXPECTATION, TRUE_EXPECTATION } from './variables/boolean.const';
+import { FUNCTION } from './variables/function.const';
+import { NULL } from './variables/null.const';
+import { NUMBER, NUMBER_INSTANCE, NUMBER_NEW_INSTANCE } from './variables/number.const';
+import { OBJECT_ONE, OBJECT_TWO, OBJECT_ONE_NEW, OBJECT_TWO_NEW, ObjectTwo, ObjectOne } from './variables/object.const';
+import { STRING, STRING_INSTANCE, STRING_NEW_INSTANCE } from './variables/string.const';
+import { SYMBOL_NUMBER, SYMBOL_STRING } from './variables/symbol.const';
+import { UNDEFINED } from './variables/undefined.const';
+
+describe(isObjectKeyIn.name , () => {
+  // Defined.
+  it('is DEFINED', () => expect(isObjectKeyIn).toBeDefined());
+
+  // Checks ...
+  describe(`checks`, () => {
+    it('callback', () => {
+      isObjectKeyIn(CLASS, ['firstName', 'surname'], (result: boolean, value: Class) => {
+        expect(result).toBe(TRUE);
+        expect(value).toEqual(CLASS);
+        return result;
+      });
+    });
+    // ... instance.
+    describe(`instance`, () => {
+      describe(`CLASS`, () => {
+        // number.
+        it('has number key', () => {
+          expect(isObjectKeyIn(CLASS, 1030405027)).toBe(TRUE);
+          expect(isObjectKeyIn(CLASS, 5)).toBe(TRUE);
+          expect(isObjectKeyIn(CLASS, NUMBER)).toBe(TRUE); // It does find getter number
+          expect(isObjectKeyIn(CLASS, [5, 1030405027])).toBe(TRUE);
+        });
+
+        // string.
+        it('has string key', () => {
+          expect(isObjectKeyIn(CLASS, 'surname')).toBe(TRUE);
+          expect(isObjectKeyIn(CLASS, ['firstName', 'surname'])).toBe(TRUE);
+        });
+
+        // symbol.
+        it('has getter symbol key', () => {
+          // It does find getter symbol key
+          expect(isObjectKeyIn(CLASS, SYMBOL_NUMBER)).toBe(TRUE);
+          expect(isObjectKeyIn(CLASS, SYMBOL_STRING)).toBe(TRUE);
+          expect(isObjectKeyIn(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING])).toBe(TRUE);
+        });
+
+        // mixed.
+        it('has string and number key', () => expect(isObjectKeyIn(CLASS, [1030405027, 'firstName', 'surname'])).toBe(TRUE));
+      });
+    });
+
+    // ... function.
+    describe(`function`, () => {
+      it(`FUNCTION`, () => expect(isObjectKeyIn(FUNCTION, 'function')).toBe(FALSE));
+      it(`CLASS`, () => expect(isObjectKeyIn(Class, 'function')).toBe(FALSE));
+    });
+
+    // ... objects.
+    describe('object', () => {
+      describe(`OBJECT_ONE`, () => {
+        // number.
+        it('has number key', () => {
+          expect(isObjectKeyIn(OBJECT_ONE, 1030405027)).toBe(TRUE);
+          expect(isObjectKeyIn(OBJECT_ONE, 5)).toBe(TRUE);
+          expect(isObjectKeyIn(OBJECT_ONE, NUMBER)).toBe(TRUE); // It doesn't find getter
+          expect(isObjectKeyIn(OBJECT_ONE, [5, 1030405027])).toBe(TRUE);
+        });
+
+        // string.
+        it('has string key', () => {
+          expect(isObjectKeyIn(OBJECT_ONE, 'key as string')).toBe(TRUE);
+          expect(isObjectKeyIn(OBJECT_ONE, 'x')).toBe(TRUE);
+          expect(isObjectKeyIn(OBJECT_ONE, STRING)).toBe(TRUE);
+          expect(isObjectKeyIn(OBJECT_ONE, ['key as string', 'x', STRING])).toBe(TRUE);
+        });
+
+        // symbol.
+        it('has symbol key', () => {
+          expect(isObjectKeyIn(OBJECT_ONE, SYMBOL_NUMBER)).toBe(TRUE);
+          expect(isObjectKeyIn(OBJECT_ONE, SYMBOL_STRING)).toBe(TRUE);
+          expect(isObjectKeyIn(OBJECT_ONE, [SYMBOL_NUMBER, SYMBOL_STRING])).toBe(TRUE);
+        });
+
+        // mixed.
+        it('has mixed key', () => {
+          expect(isObjectKeyIn(OBJECT_ONE, [
+            'key as string',
+            'x',
+            1030405027,
+            5,
+            NUMBER,
+            STRING,
+            SYMBOL_NUMBER,
+            SYMBOL_STRING,
+          ])).toBe(TRUE);
+        });
+      });
+    });
+
+    // ... primitives.
+    describe(`primitive`, () => {
+      // bigint
+      describe(`bigint`, () => {
+        it(`${BIGINT}`, () => expect(isObjectKeyIn(BIGINT, 'bigint')).toBe(FALSE));
+        it(`${BIGINT_EXPECTATION}`, () => expect(isObjectKeyIn(BIGINT_INSTANCE, 'bigint')).toBe(FALSE));
+      });
+
+      // boolean
+      describe(`boolean`, () => {
+        it(`${TRUE}`, () => expect(isObjectKeyIn(TRUE, 'boolean')).toBe(FALSE));
+        it(`${FALSE}`, () => expect(isObjectKeyIn(FALSE, 'boolean')).toBe(FALSE));
+        it(`${FALSE_EXPECTATION}`, () => expect(isObjectKeyIn(TRUE_INSTANCE, 'boolean')).toBe(FALSE));
+        it(`${TRUE_EXPECTATION}`, () => expect(isObjectKeyIn(FALSE_INSTANCE, 'boolean')).toBe(FALSE));
+      });
+
+      // null
+      it(`${NULL}`, () => expect(isObjectKeyIn(NULL, 'null')).toBe(FALSE));
+
+      // number
+      describe(`number`, () => {
+        it(`${NUMBER}`, () => expect(isObjectKeyIn(NUMBER, 'number')).toBe(FALSE));
+        it(`Number(${NUMBER})`, () => expect(isObjectKeyIn(NUMBER_INSTANCE, 'number')).toBe(FALSE));
+        it(`new Number(${NUMBER})`, () => expect(isObjectKeyIn(NUMBER_NEW_INSTANCE, 'number')).toBe(FALSE));
+      });
+
+      // string
+      describe(`string`, () => {
+        it(`${STRING}`, () => expect(isObjectKeyIn(STRING, 'string')).toBe(FALSE));
+        it(`String(${STRING})`, () => expect(isObjectKeyIn(STRING_INSTANCE, 'string')).toBe(FALSE));
+        it(`new String(${STRING})`, () => expect(isObjectKeyIn(STRING_NEW_INSTANCE, 'string')).toBe(FALSE));
+      });
+
+      // symbol
+      describe(`symbol`, () => {
+        it(`Symbol(${NUMBER})`, () => expect(isObjectKeyIn(SYMBOL_NUMBER, 'symbol')).toBe(FALSE));
+        it(`Symbol(${STRING})`, () => expect(isObjectKeyIn(SYMBOL_STRING, 'symbol')).toBe(FALSE));
+      });
+
+      // undefined
+      it(`${UNDEFINED}`, () => expect(isObjectKeyIn(UNDEFINED, 'undefined')).toBe(FALSE));
+    });
+  });
+});

--- a/packages/type/src/is/test/is-object-key.spec.ts
+++ b/packages/type/src/is/test/is-object-key.spec.ts
@@ -19,8 +19,9 @@ describe(isObjectKey.name , () => {
   // Checks ...
   describe(`checks`, () => {
     it('callback', () => {
-      isObjectKey(CLASS, ['firstName', 'surname'], (result: boolean) => {
+      isObjectKey(CLASS, ['firstName', 'surname'], (result: boolean, value: Class) => {
         expect(result).toBe(TRUE);
+        expect(value).toEqual(CLASS);
         return result;
       });
     });
@@ -31,9 +32,11 @@ describe(isObjectKey.name , () => {
         it('has number key', () => {
           expect(isObjectKey(CLASS, 1030405027)).toBe(TRUE);
           expect(isObjectKey(CLASS, 5)).toBe(TRUE);
-          expect(isObjectKey(CLASS, NUMBER)).toBe(FALSE); // It doesn't find getter
           expect(isObjectKey(CLASS, [5, 1030405027])).toBe(TRUE);
         });
+
+        // It doesn't find getter number
+        it('has not find getter number', () => expect(isObjectKey(CLASS, NUMBER)).toBe(FALSE));
 
         // string.
         it('has string key', () => {
@@ -42,7 +45,8 @@ describe(isObjectKey.name , () => {
         });
 
         // symbol.
-        it('has symbol key', () => {
+        it('has not find getter symbol key', () => {
+          // It does not find getter symbol key in class
           expect(isObjectKey(CLASS, SYMBOL_NUMBER)).toBe(FALSE);
           expect(isObjectKey(CLASS, SYMBOL_STRING)).toBe(FALSE);
           expect(isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING])).toBe(FALSE);

--- a/packages/type/src/is/test/is-object.spec.ts
+++ b/packages/type/src/is/test/is-object.spec.ts
@@ -48,14 +48,14 @@ describe(isObject.name, () => {
       it(`new Object(OBJECT_TWO_NEW})`, () => expect(isObject(OBJECT_TWO_NEW)).toBe(TRUE));
 
       describe('OBJECT_ONE has the', () => {
-        it(`'key as string'`, () => expect(isObject(OBJECT_ONE, 'key as string')).toBe(TRUE));
-        it(`key as string ${STRING}`, () => expect(isObject(OBJECT_ONE, STRING)).toBe(TRUE));
-        it(`key as string instance ${STRING_NEW_INSTANCE}`, () => expect(isObject(OBJECT_ONE, STRING_NEW_INSTANCE)).toBe(TRUE));
-        it(`key as number ${1030405027}`, () => expect(isObject(OBJECT_ONE, 1030405027)).toBe(TRUE));
-        it(`key as number ${NUMBER}`, () => expect(isObject(OBJECT_ONE, NUMBER)).toBe(TRUE));
-        it(`key as number instance ${NUMBER_NEW_INSTANCE}`, () => expect(isObject(OBJECT_ONE, NUMBER_NEW_INSTANCE)).toBe(TRUE));
-        it(`key as SYMBOL_NUMBER`, () => expect(isObject(OBJECT_ONE, SYMBOL_NUMBER)).toBe(TRUE));
-        it(`key as SYMBOL_STRING`, () => expect(isObject(OBJECT_ONE, SYMBOL_STRING)).toBe(TRUE));
+        // it(`'key as string'`, () => expect(isObject(OBJECT_ONE, 'key as string')).toBe(TRUE));
+        // it(`key as string ${STRING}`, () => expect(isObject(OBJECT_ONE, STRING)).toBe(TRUE));
+        // it(`key as string instance ${STRING_NEW_INSTANCE}`, () => expect(isObject(OBJECT_ONE, STRING_NEW_INSTANCE)).toBe(TRUE));
+        // it(`key as number ${1030405027}`, () => expect(isObject(OBJECT_ONE, 1030405027)).toBe(TRUE));
+        // it(`key as number ${NUMBER}`, () => expect(isObject(OBJECT_ONE, NUMBER)).toBe(TRUE));
+        // it(`key as number instance ${NUMBER_NEW_INSTANCE}`, () => expect(isObject(OBJECT_ONE, NUMBER_NEW_INSTANCE)).toBe(TRUE));
+        // it(`key as SYMBOL_NUMBER`, () => expect(isObject(OBJECT_ONE, SYMBOL_NUMBER)).toBe(TRUE));
+        // it(`key as SYMBOL_STRING`, () => expect(isObject(OBJECT_ONE, SYMBOL_STRING)).toBe(TRUE));
       });
     });
     // ... primitives.

--- a/packages/type/src/is/test/is-object.spec.ts
+++ b/packages/type/src/is/test/is-object.spec.ts
@@ -22,18 +22,16 @@ describe(isObject.name, () => {
 
   // Checks ...
   describe(`checks`, () => {
-    // it('callback', () => {
-      // isObject(OBJECT_ONE, (result: boolean) => {
-      //   expect(result).toBe(TRUE);
-      //   return result;
-      // });
-    // });
+    it('callback', () => {
+      isObject(OBJECT_ONE, (result: boolean, value: ObjectOne) => {
+        expect(result).toBe(TRUE);
+        expect(value).toEqual(OBJECT_ONE);
+        return result;
+      });
+    });
 
     // ... arrays.
-    describe(`array`, () => {
-      // it(`${FUNCTION}`, () => expect(isObject(FUNCTION, 'function')).toBe(FALSE));
-      // it(`${Class}`, () => expect(isObject(Class, 'function')).toBe(FALSE));
-    });
+    describe(`array`, () => {});
     // ... function.
     describe(`function`, () => {
       it(`FUNCTION`, () => expect(isObject(FUNCTION)).toBe(FALSE));
@@ -46,17 +44,6 @@ describe(isObject.name, () => {
       it(`OBJECT_TWO`, () => expect(isObject(OBJECT_TWO)).toBe(TRUE));
       it(`new Object(OBJECT_ONE_NEW})`, () => expect(isObject(OBJECT_ONE_NEW)).toBe(TRUE));
       it(`new Object(OBJECT_TWO_NEW})`, () => expect(isObject(OBJECT_TWO_NEW)).toBe(TRUE));
-
-      describe('OBJECT_ONE has the', () => {
-        // it(`'key as string'`, () => expect(isObject(OBJECT_ONE, 'key as string')).toBe(TRUE));
-        // it(`key as string ${STRING}`, () => expect(isObject(OBJECT_ONE, STRING)).toBe(TRUE));
-        // it(`key as string instance ${STRING_NEW_INSTANCE}`, () => expect(isObject(OBJECT_ONE, STRING_NEW_INSTANCE)).toBe(TRUE));
-        // it(`key as number ${1030405027}`, () => expect(isObject(OBJECT_ONE, 1030405027)).toBe(TRUE));
-        // it(`key as number ${NUMBER}`, () => expect(isObject(OBJECT_ONE, NUMBER)).toBe(TRUE));
-        // it(`key as number instance ${NUMBER_NEW_INSTANCE}`, () => expect(isObject(OBJECT_ONE, NUMBER_NEW_INSTANCE)).toBe(TRUE));
-        // it(`key as SYMBOL_NUMBER`, () => expect(isObject(OBJECT_ONE, SYMBOL_NUMBER)).toBe(TRUE));
-        // it(`key as SYMBOL_STRING`, () => expect(isObject(OBJECT_ONE, SYMBOL_STRING)).toBe(TRUE));
-      });
     });
     // ... primitives.
     describe(`primitive`, () => {

--- a/packages/type/src/is/test/is-object.spec.ts
+++ b/packages/type/src/is/test/is-object.spec.ts
@@ -22,13 +22,13 @@ describe(isObject.name, () => {
 
   // Checks ...
   describe(`checks`, () => {
-    it('callback', () => {
-      isObject(OBJECT_ONE, (result: boolean, value: ObjectOne) => {
-        expect(result).toBe(TRUE);
-        expect(value).toEqual(OBJECT_ONE);
-        return result;
-      });
-    });
+    // it('callback', () => {
+    //   isObject(OBJECT_ONE, (result: boolean, value: ObjectOne) => {
+    //     expect(result).toBe(TRUE);
+    //     expect(value).toEqual(OBJECT_ONE);
+    //     return result;
+    //   });
+    // });
 
     // ... arrays.
     describe(`array`, () => {});

--- a/packages/type/src/is/test/is.spec.ts
+++ b/packages/type/src/is/test/is.spec.ts
@@ -18,6 +18,7 @@ describe('`is`', () => {
       it('is.numberType()', () => expect(is.numberType).toBeDefined());
       it('is.object()', () => expect(is.object).toBeDefined());
       it('is.objectKey()', () => expect(is.objectKey).toBeDefined());
+      it('is.objectKeyIn()', () => expect(is.objectKeyIn).toBeDefined());
       it('is.primitive()', () => expect(is.primitive).toBeDefined());
       it('is.string()', () => expect(is.string).toBeDefined());
       it('is.stringObject()', () => expect(is.stringObject).toBeDefined());

--- a/packages/type/src/is/type/is-object-key-in.type.ts
+++ b/packages/type/src/is/type/is-object-key-in.type.ts
@@ -1,0 +1,3 @@
+import { Key } from '../../type/key.type';
+import { ResultCallback } from '../../type/result-callback.type';
+export type IsObjectKeyIn = <Type extends object>(value: any, key: Key | Key[], callback?: ResultCallback) => value is Type;

--- a/packages/type/src/is/type/is-object.type.ts
+++ b/packages/type/src/is/type/is-object.type.ts
@@ -1,2 +1,2 @@
-import { Key } from '../../type/key.type';
-export type IsObject = <Obj = object>(value: any, key?: Key) => value is Obj;
+import { ResultCallback } from '../../type/result-callback.type';
+export type IsObject = <Obj = object>(value: any, callback?: ResultCallback) => value is Obj;

--- a/packages/type/src/is/type/is-object.type.ts
+++ b/packages/type/src/is/type/is-object.type.ts
@@ -1,2 +1,2 @@
-import { ResultCallback } from '../../type/result-callback.type';
-export type IsObject = <Obj = object>(value: any, callback?: ResultCallback) => value is Obj;
+import { Key } from '../../type/key.type';
+export type IsObject = <Obj = object>(value: any, key?: Key) => value is Obj;

--- a/packages/type/src/lib/result-callback.func.ts
+++ b/packages/type/src/lib/result-callback.func.ts
@@ -1,2 +1,7 @@
 import { ResultCallback } from '../type/result-callback.type';
+/**
+ * Default function to handle `callback`.
+ * @param result A `boolean` type value from the result of the check.
+ * @returns result A `boolean` type result from the check.
+ */
 export const resultCallback: ResultCallback = (result: boolean): boolean => result;

--- a/packages/type/src/public-api.ts
+++ b/packages/type/src/public-api.ts
@@ -50,6 +50,7 @@ export {
   isNumberType,
   isObject,
   isObjectKey,
+  isObjectKeyIn,
   isPrimitive,
   isString,
   isStringObject,
@@ -58,6 +59,9 @@ export {
   isType,
   isUndefined
 } from './is';
+
+// `is` interface.
+export { Is } from './is/interface/is.interface';
 
 // `isNot` functions.
 export {

--- a/packages/type/src/public-api.ts
+++ b/packages/type/src/public-api.ts
@@ -60,9 +60,6 @@ export {
   isUndefined
 } from './is';
 
-// `is` interface.
-export { Is } from './is/interface/is.interface';
-
 // `isNot` functions.
 export {
   isNotBoolean,

--- a/packages/type/src/type/result-callback.type.ts
+++ b/packages/type/src/type/result-callback.type.ts
@@ -1,1 +1,1 @@
-export type ResultCallback = (result: boolean) => boolean;
+export type ResultCallback = <Obj>(result: boolean, value?: any) => boolean;


### PR DESCRIPTION
Added:

- Feature `isOjectKeyIn()` to checks if any `value` is an `Object` with the `key` of the `Key` type by using the `in` operator 
[`382ea1b`][382ea1b] [`07cf4ee`][07cf4ee] [`148e8de`][148e8de]  [`16ef1bf`][16ef1bf]

Updated:
- Function `callbackResult()` with `value` parameter [`fcf2f47`][fcf2f47]

[10bb3ab]: https://github.com/angular-package/type/commit/10bb3ab371173d7f919068fd3122c100916c0487
[fcf2f47]: https://github.com/angular-package/type/commit/fcf2f4745305a1ae686c93fcb9c473b0c1feb48a

[382ea1b]: https://github.com/angular-package/type/commit/382ea1be91c7ff32a00de08eddd7dfb909436c50
[16ef1bf]: https://github.com/angular-package/type/commit/16ef1bf441077d0b996cc1bedcf8cfbffc86110e
[148e8de]: https://github.com/angular-package/type/commit/148e8dedc5343d01a2b6159eec27a53245fe859e
[07cf4ee]: https://github.com/angular-package/type/commit/07cf4eedc9d3d422442034b2311993c0ce256fa5