### PR TITLE
4.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,14 @@ Default function to handle `callback`.
 const resultCallback: ResultCallback = (result: boolean, value?: any): boolean => result;
 ```
 
-| Parameter | Type      | Description                             |
-| :-------- | :-------: | :-------------------------------------- |
-| result    | `boolean` | A `boolean` type value from the result of the check   |
-| value     | `any`     | Any type value from the check |
+| Parameter | Type      | Description                                         |
+| :-------- | :-------: | :-------------------------------------------------- |
+| result    | `boolean` | A `boolean` type value from the result of the check |
+| value     | `any`     | Any type value from the check                       |
 
-The **return value** is a `boolean` type result from the check.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` type result from the check |
 
 Custom function to handle `callback`.
 
@@ -257,7 +259,9 @@ const areString = (...value: any): boolean => check('string', ...value);
 | :-------- | :---: | :------------------ |
 | ...value  | `any` | Any values to check |
 
-The **return value** is a `boolean` indicating whether or not all the values are an `Array`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not all the values are an [`Array`][array] |
 
 [Example usage on playground][are-string]
 
@@ -302,10 +306,14 @@ const is: Is = {
 
 ### isArray
 
+![update][update]
+
+`4.1.0`: Type variable `Class` default value is set to `any`.
+
 Use `isArray()` or `is.array()` to check if **any** `value` is an [`Array`][array], [`Array`][array] instance, and `object` type.
 
 ```typescript
-const isArray: IsArray = <Type>(value: any, callback: ResultCallback = resultCallback): value is Array<Type> =>
+const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = resultCallback): value is Array<Type> =>
   callback(
     typeOf(value) === 'array' &&
     Array.isArray(value) === true &&
@@ -315,12 +323,18 @@ const isArray: IsArray = <Type>(value: any, callback: ResultCallback = resultCal
   );
 ```
 
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Type`         | `any`         | A generic variable to returned check `value is Array<Type>` |
+
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array].
+| Return value           | Description |
+| :--------------------- | :---------- |
+| `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
 ```typescript
 // Example usage
@@ -352,7 +366,9 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `bigint`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
 ```typescript
 // Example usage
@@ -384,7 +400,9 @@ const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallb
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `boolean`.
+| Return value       | Description |
+| :----------------- | :---------- |
+| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -416,7 +434,9 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance.
+| Return value       | Description |
+| :----------------- | :---------- |
+| `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -452,7 +472,9 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type.
+| Return value       | Description |
+| :----------------- | :---------- |
+| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
 ```typescript
 // Example usage
@@ -470,12 +492,14 @@ isBooleanType(BOOLEAN_INSTANCE); // false
 
 ### isClass
 
-![new][new]
+![update][update]
+
+`4.1.0`: Type variable `Class` default value is set to [`Function`][function].
 
 Use `isClass()` or `is.class()` to check if **any** `value` is a `function` type, an instance of [`Function`][function] and [`Object`][object] as a generic `Class` type of [`class`][classes].
 
 ```typescript
-const isClass: IsClass = <Class>(value: any, callback: ResultCallback = resultCallback): value is Class =>
+const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback = resultCallback): value is Class =>
   callback(
     (
       typeOf(value) === 'function' &&
@@ -484,17 +508,23 @@ const isClass: IsClass = <Class>(value: any, callback: ResultCallback = resultCa
       value instanceof Object === true
     ) ?
       /class/.test(Function.prototype.toString.call(value).slice(0, 5))
-    : false,
+      : false,
     value
   );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Class`        | `Function`    | A generic variable to returned check `value is Class` |
 
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `class`.
+| Return value     | Description |
+| :--------------- | :---------- |
+| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
 ```typescript
 // Example usage
@@ -525,7 +555,9 @@ const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An `unknown` `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined`.
+| Return value | Description |
+| :----------- | :---------- |
+| `boolean`    | The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined` |
 
 ```typescript
 // Example usage
@@ -559,7 +591,7 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
       value instanceof Object === true
     ) ?
       /class/.test(Function.prototype.toString.call(value).slice(0, 5)) === false
-    : false,
+      : false,
     value
   );
 ```
@@ -569,7 +601,9 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `function`.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
 ```typescript
 // Example usage
@@ -595,23 +629,26 @@ isFunction(() => 5); // true
 
 `4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
+`4.1.0`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
+
 Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
 
 ```typescript
-const isInstance: IsInstance = <Obj>(
-    value: any,
-    className: Constructor<Obj>,
-    callback: ResultCallback = resultCallback
-  ): value is Obj =>
+const isInstance: IsInstance =
+  <Class>(value: any, className: Constructor<Class>, callback: ResultCallback = resultCallback): value is Constructor<Class> =>
     callback(
-      isObject<Obj>(value) ?
+      isObject<Class>(value) ?
         isClass(className) ?
           value instanceof className === true
-        : false
-      : false,
+          : false
+        : false,
       value
     );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Class`        |               | A generic variable to returned check `value is Constructor<Class>` |
 
 | Parameter | Type                                                            | Description                                |
 | :-------- | :-------------------------------------------------------------: | :----------------------------------------- |
@@ -619,7 +656,9 @@ const isInstance: IsInstance = <Obj>(
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Obj`.
+| Return value     | Description |
+| :--------------- | :---------- |
+| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
 ```typescript
 // Example usage
@@ -655,7 +694,9 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key].
+| Return value   | Description |
+| :------------- | :---------- |
+| `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
 ```typescript
 // Example usage
@@ -694,7 +735,9 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is `null`.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
 ```typescript
 // Example usage
@@ -739,7 +782,9 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `number`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 [Example usage on playground][is-number] | [How to detect a `number` type][detect-number]
 
@@ -759,7 +804,9 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
 ```typescript
 // Example usage
@@ -811,7 +858,9 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `number`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 ```typescript
 // Example usage
@@ -862,11 +911,17 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
   callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);
 ```
 
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Obj`          | `object`      | A generic variable to returned check `value is Obj` |
+
 | Parameter | Type   | Description          |
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `object`.
+| Return value   | Description |
+| :------------- | :---------- |
+| `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
 [Example usage on playground][is-object] | [How to detect an `object` type][detect-object]
 
@@ -931,26 +986,31 @@ isObject(OBJECT_ONE); // true
 
 ### isObjectKey
 
+![update][update]
+
+`4.1.0` Type variable `Type` default value is set to `object`.
+
 Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
 The function uses [`hasOwnProperty`][hasownproperty] [`Object`][object] method to finds enumerable and non-enumerable [`Key`][key] as `string`, `number`, `symbol` unlike `Object.keys()` but it can't find accessor descriptor property unlike `in` operator which can.
 
 ```typescript
-const isObjectKey: IsObjectKey = <Type = object>(
-  value: any,
-  key: Key | Key[],
-  callback: ResultCallback = resultCallback
-): value is Type =>
-  callback(
-    isObject<Type>(value) ?
-      isArray(key) ?
-        key.every(k => isKey(k) ? ({}).hasOwnProperty.call(value, k) === true : false)
-      : isKey(key) ?
-          ({}).hasOwnProperty.call(value, key)
-        : false
-    : false,
-    value
-  );
+const isObjectKey: IsObjectKey =
+  <Type = object>(value: any, key: Key | Key[], callback: ResultCallback = resultCallback): value is Type =>
+    callback(
+      isObject<Type>(value) ?
+        isArray(key) ?
+          key.every(k => isKey(k) ? ({}).hasOwnProperty.call(value, k) === true : false)
+          : isKey(key) ?
+            ({}).hasOwnProperty.call(value, key)
+            : false
+        : false,
+      value
+    );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Type`         | `object`      | A generic variable to returned check `value is Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -958,7 +1018,9 @@ const isObjectKey: IsObjectKey = <Type = object>(
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
 ```typescript
 // Example usage
@@ -1072,25 +1134,30 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ### isObjectKeyIn
 
+![update][update]
+
+`4.1.0` Type variable `Type` default value is set to `object`.
+
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
 ```typescript
-const isObjectKeyIn: IsObjectKeyIn = <Type = object>(
-  value: any,
-  key: Key | Key[],
-  callback: ResultCallback = resultCallback
-): value is Type =>
-  callback(
-    isObject<Type>(value) ?
-      isArray(key) ?
-        key.every(k => isKey(k) ? k in value : false)
-      : isKey(key) ?
-          key in value
-        : false
-    : false,
-    value
-  );
+const isObjectKeyIn: IsObjectKeyIn =
+  <Type = object>(value: any, key: Key | Key[], callback: ResultCallback = resultCallback): value is Type =>
+    callback(
+      isObject<Type>(value) ?
+        isArray(key) ?
+          key.every(k => isKey(k) ? k in value : false)
+          : isKey(key) ?
+            key in value
+            : false
+        : false,
+      value
+    );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Type`         | `object`      | A generic variable to returned check `value is Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -1098,7 +1165,9 @@ const isObjectKeyIn: IsObjectKeyIn = <Type = object>(
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
 ```typescript
 import { isObjectKeyIn } from '@angular-package/type';
@@ -1232,7 +1301,9 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
 ----
 
@@ -1250,7 +1321,9 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
 ----
 
@@ -1268,7 +1341,9 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `string` type.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
 ----
 
@@ -1286,7 +1361,9 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `symbol`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
 [Example usage on playground][is-symbol] | [How to detect `symbol` type][detect-symbol]
 
@@ -1327,7 +1404,9 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types).
+| Return value | Description |
+| :----------- | :---------- |
+| `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
 [Example usage on playground][is-type]
 
@@ -1347,7 +1426,9 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is `undefined`.
+| Return value         | Description |
+| :------------------- | :---------- |
+| `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
 [Example usage on playground][is-undefined] | [How to detect `undefined` type][detect-undefined]
 
@@ -1390,7 +1471,9 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` |
 
 ----
 
@@ -1408,7 +1491,9 @@ const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined` |
 
 ----
 
@@ -1426,7 +1511,9 @@ const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback =
 | value     | `unknown` | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `function`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `function` |
 
 ----
 
@@ -1444,7 +1531,9 @@ const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not `null`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `null` |
 
 ----
 
@@ -1467,7 +1556,9 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `number`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `number` |
 
 ----
 
@@ -1485,7 +1576,9 @@ const isNotString: IsNotString = (value: unknown, callback: ResultCallback = res
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `string`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `string` |
 
 ----
 
@@ -1503,7 +1596,9 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not `undefined`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `undefined` |
 
 ```typescript
 // Example usage with the problem
@@ -1859,12 +1954,38 @@ const guardObjectKey: GuardObjectKey =
 | Parameter   | Type                               | Description                                                            |
 | :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
 | value       | `Obj`                              | A generic `Obj` type `value` that contains the `key` to guard          |
-| key         | `keyof Obj` \| `(keyof Obj)[]`     | A key of `Obj` or an array key of `Obj` type as the name of the property that the `value` contains |
+| key         | `keyof Obj` \| `(keyof Obj)[]`     | A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains |
 | callback?   | [`ResultCallback`][resultcallback] | An Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` of a generic `Obj` containing the `key`.
 
 [Example usage on playground][guard-object-key]
+
+----
+
+### guardObjectKeys
+
+![new][new]
+
+Use `guardObjectKeys()` or `guard.is.objectKeys()` to guard the `value` to be an `object` of a generic `Obj` with some of its own specified `keys`.
+
+```typescript
+const guardObjectKeys: GuardObjectKeys =
+  <Obj = object>(value: Obj, ...keys: (keyof Obj | Array<keyof Obj>)[]): value is Obj =>
+    isObjectKeys<Obj>(value, ...keys);
+```
+
+| Parameter   | Type                               | Description                                                            |
+| :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
+| value       | `Obj`                              | A generic `Obj` type `value` that contains the `keys` to guard         |
+| ...keys     | `(keyof Obj | Array<keyof Obj>)[]` | A rest parameter single key of `Obj` or an array of keys of `Obj`, as the name of the property that the `value` contains |
+
+The **return value** is a `boolean` indicating whether or not the `value` is an `object` with some of its own specified `keys`.
+
+```typescript
+// Example usage
+
+```
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -1927,7 +1927,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
 
-`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
+`4.0.3`: Fix type variable `Obj` default value is set to cause of it always being picked from the `value`.
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 
@@ -1959,7 +1959,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 `4.0.1`: Fix guards the `key` by changing its type to `keyof Obj` instead of just a [`Key`][key].
 
-`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
+`4.0.3`: Fix type variable `Obj` default value is set to cause of it always being picked from the `value`.
 
 Use `guardObjectKey()` or `guard.is.objectKey()` to guard the `value` to be an `object` of a generic `Obj` type that contains the `key`.
 
@@ -1987,7 +1987,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ### guardPrimitive
 
-Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`][primitive] from a `type` of the [`Primitives`][primitives].
+Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`][primitive] from a `type` of the [`Primitives`](#primitives).
 
 ```typescript
 const guardPrimitive: GuardPrimitive =
@@ -1995,14 +1995,14 @@ const guardPrimitive: GuardPrimitive =
     isPrimitive<Type>(value, type, callback);
 ```
 
-| Type variable                           | Default value    | Description |
-| :-------------------------------------- | :--------------- | :---------- |
-| `Type` extends [`Primitive`][primitive] | From the `value` | Guarded with [`Primitive`][primitive] type `Type` variable from the `value` to the return type `value` is `Type` |
+| Type variable                            | Default value    | Description |
+| :--------------------------------------- | :--------------- | :---------- |
+| `Type` extends [`Primitive`](#primitive) | From the `value` | Guarded with [`Primitive`](#primitive) type `Type` variable from the `value` to the return type `value` is `Type` |
 
 | Parameter   | Type                                     | Description                         |
 | :---------- | :--------------------------------------: | :---------------------------------- |
-| value       | `Type` extends [`Primitive`][primitive] | A `Primitive` type `value` to guard |
-| type        | [`Primitives`][primitives]              | A `string` type from the [`Primitives`][primitives] to check the `value` |
+| value       | `Type` extends [`Primitive`](#primitive) | A `Primitive` type `value` to guard |
+| type        | [`Primitives`](#primitives)              | A `string` type from the [`Primitives`](#primitives) to check the `value` |
 | callback?   | [`ResultCallback`][resultcallback]       | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is the [`Primitive`][primitive] from the `type`.
@@ -2062,8 +2062,8 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
   isType<T>(value, type, callback);
 ```
 
-| Type variable                 | Default value    | Description |
-| :---------------------------- | :--------------- | :---------- |
+| Type variable              | Default value    | Description |
+| :------------------------- | :--------------- | :---------- |
 | `T` extends [`Type`][type] | From the `value` | Guarded with [`Type`][type] type `T` variable from the `value` to the return type `value` is `T` |
 
 | Parameter | Type                               | Description                                        |

--- a/README.md
+++ b/README.md
@@ -625,11 +625,11 @@ isFunction(() => 5); // true
 
 ![update][update]
 
-`4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
+`4.0.0`: The function uses [`isClass()`](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
 `4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value` is `Constructor<Class>`.
 
-Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
+Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor<Class>`](#constructor) type.
 
 ```typescript
 const isInstance: IsInstance =
@@ -651,7 +651,7 @@ const isInstance: IsInstance =
 | Parameter | Type                                                            | Description                                |
 | :-------- | :-------------------------------------------------------------: | :----------------------------------------- |
 | value     | `any`                                                           | Any `value` to compare with the `instance` |
-| instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
+| instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor<Obj>`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 | Type return        | Description |
@@ -1393,7 +1393,7 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | Parameter | Type                                                            | Description                                         |
 | :-------- | :-------------------------------------------------------------: | :-------------------------------------------------- |
 | value     | `any`                                                           | Any `value` to check if its type is from the `type` |
-| type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
+| type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor<T>` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 | Type return    | Description |
@@ -1840,7 +1840,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is a [
 
 `4.0.0`: The function uses an updated [`isInstance()`](#isinstance) function that uses [`isClass()`](#isclass).
 
-Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
+Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `object` of a generic `Obj` type equal to an `instance` of [`Constructor<Obj>`](#constructor) type.
 
 ```typescript
 const guardInstance: GuardInstance = <Obj>(value: Obj, instance: Constructor<Obj>, callback?: ResultCallback): value is Obj =>
@@ -2069,7 +2069,7 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
 | Parameter | Type                               | Description                                        |
 | :-------- | :--------------------------------: | :------------------------------------------------- |
 | value     | `T` extends [`Type`][type]         | A [`Type`][type] `value` to guard with the `type` |
-| type      | [`Types<T>`](#types)               | A `string` or generic [`Constructor`](#constructor) type from the [`Types`](#types) to check the `value` |
+| type      | [`Types<T>`](#types)               | A `string` or generic [`Constructor<T>`](#constructor) type from the [`Types`](#types) to check the `value` |
 | callback? | [`ResultCallback`][resultcallback] | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is a `type` from the [`Types`](#types).

--- a/README.md
+++ b/README.md
@@ -898,11 +898,7 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
-![update][update]
-
 `4.0.0`: The function no longer checks the `key` but has `callback` instead. Use [`isObjectKeyIn`](#isobjectkeyin) or [`isObjectKey`](#isobjectkey) to check object with the [`Key`][key] .
-
-`4.0.3`: Type  variable `Obj`  default value is set to `object`.
 
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
@@ -1133,10 +1129,6 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 ----
 
 ### isObjectKeyIn
-
-![update][update]
-
-`4.0.3`: Type variable `Type` default value is set to `object`.
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
@@ -1931,7 +1923,11 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 ### guardObject
 
+![update][update]
+
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
+
+`4.0.3`: Type variable `Obj` default value is not set to cause of it always being picked from the `value`.
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 
@@ -1957,9 +1953,13 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ### guardObjectKey
 
+![update][update]
+
 `4.0.0`: The function uses [`isObjectKey`](#isobjectkey) function to check the `value` and has [`callback`](#resultcallback) as optional instead of the [`guardObject`](#guardobject).
 
 `4.0.1`: Fix guards the `key` by changing its type to `keyof Obj` instead of just a [`Key`][key].
+
+`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
 
 Use `guardObjectKey()` or `guard.is.objectKey()` to guard the `value` to be an `object` of a generic `Obj` type that contains the `key`.
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ const resultCallback: ResultCallback = (result: boolean, value?: any): boolean =
 | result    | `boolean` | A `boolean` type value from the result of the check |
 | value     | `any`     | Any type value from the check                       |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` type result from the check |
 
@@ -259,7 +259,7 @@ const areString = (...value: any): boolean => check('string', ...value);
 | :-------- | :---: | :------------------ |
 | ...value  | `any` | Any values to check |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not all the values are an [`Array`][array] |
 
@@ -308,7 +308,7 @@ const is: Is = {
 
 ![update][update]
 
-`4.1.0`: Type variable `Class` default value is set to `any`.
+`4.0.3`: Type variable `Class` default value is set to `any`.
 
 Use `isArray()` or `is.array()` to check if **any** `value` is an [`Array`][array], [`Array`][array] instance, and `object` type.
 
@@ -332,7 +332,7 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value           | Description |
+[ Type return            | Description |
 | :--------------------- | :---------- |
 | `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
@@ -366,7 +366,7 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
@@ -400,7 +400,7 @@ const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallb
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value       | Description |
+| Type return        | Description |
 | :----------------- | :---------- |
 | `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
 
@@ -434,7 +434,7 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value       | Description |
+[ Type return        | Description |
 | :----------------- | :---------- |
 | `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
@@ -472,7 +472,7 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value       | Description |
+[ Type return        | Description |
 | :----------------- | :---------- |
 | `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
@@ -494,7 +494,7 @@ isBooleanType(BOOLEAN_INSTANCE); // false
 
 ![update][update]
 
-`4.1.0`: Type variable `Class` default value is set to [`Function`][function].
+`4.0.3`: Type variable `Class` default value is set to [`Function`][function].
 
 Use `isClass()` or `is.class()` to check if **any** `value` is a `function` type, an instance of [`Function`][function] and [`Object`][object] as a generic `Class` type of [`class`][classes].
 
@@ -522,7 +522,7 @@ const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value     | Description |
+[ Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
@@ -555,7 +555,7 @@ const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An `unknown` `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value | Description |
+[ Type return  | Description |
 | :----------- | :---------- |
 | `boolean`    | The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined` |
 
@@ -601,7 +601,7 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
@@ -629,7 +629,7 @@ isFunction(() => 5); // true
 
 `4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
-`4.1.0`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
+`4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
 
 Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
 
@@ -656,7 +656,7 @@ const isInstance: IsInstance =
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value     | Description |
+[ Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
@@ -694,7 +694,7 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value   | Description |
+[ Type return    | Description |
 | :------------- | :---------- |
 | `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
@@ -735,7 +735,7 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
@@ -782,7 +782,7 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -804,7 +804,7 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
@@ -858,7 +858,7 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -919,7 +919,7 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-| Return value   | Description |
+[ Type return    | Description |
 | :------------- | :---------- |
 | `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
@@ -988,7 +988,7 @@ isObject(OBJECT_ONE); // true
 
 ![update][update]
 
-`4.1.0` Type variable `Type` default value is set to `object`.
+`4.0.3` Type variable `Type` default value is set to `object`.
 
 Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
 The function uses [`hasOwnProperty`][hasownproperty] [`Object`][object] method to finds enumerable and non-enumerable [`Key`][key] as `string`, `number`, `symbol` unlike `Object.keys()` but it can't find accessor descriptor property unlike `in` operator which can.
@@ -1018,7 +1018,7 @@ const isObjectKey: IsObjectKey =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
@@ -1136,7 +1136,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ![update][update]
 
-`4.1.0` Type variable `Type` default value is set to `object`.
+`4.0.3` Type variable `Type` default value is set to `object`.
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
@@ -1165,7 +1165,7 @@ const isObjectKeyIn: IsObjectKeyIn =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
@@ -1301,7 +1301,7 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
@@ -1321,7 +1321,7 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
@@ -1341,7 +1341,7 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
@@ -1361,7 +1361,7 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
@@ -1404,7 +1404,7 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value | Description |
+[ Type return  | Description |
 | :----------- | :---------- |
 | `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
@@ -1426,7 +1426,7 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value         | Description |
+[ Type return          | Description |
 | :------------------- | :---------- |
 | `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
@@ -1471,7 +1471,7 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` |
 
@@ -1491,7 +1491,7 @@ const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined` |
 
@@ -1511,7 +1511,7 @@ const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback =
 | value     | `unknown` | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `function` |
 
@@ -1531,7 +1531,7 @@ const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `null` |
 
@@ -1556,7 +1556,7 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `number` |
 
@@ -1576,7 +1576,7 @@ const isNotString: IsNotString = (value: unknown, callback: ResultCallback = res
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `string` |
 
@@ -1596,7 +1596,7 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `undefined` |
 

--- a/README.md
+++ b/README.md
@@ -575,8 +575,6 @@ isDefined(defined); // false
 
 ### isFunction
 
-![update][update]
-
 `4.0.0`: The function denies [classes][classes] in check to differ from classes.
 
 Use `isFunction()` or `is.function()` to check if **any** `value` is a `function` type, an instance of [`Function`][function] and [`Object`][object].
@@ -904,6 +902,8 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 `4.0.0`: The function no longer checks the `key` but has `callback` instead. Use [`isObjectKeyIn`](#isobjectkeyin) or [`isObjectKey`](#isobjectkey) to check object with the [`Key`][key] .
 
+`4.0.3`: Type  variable `Obj`  default value is set to `object`.
+
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
 ```typescript
@@ -988,7 +988,7 @@ isObject(OBJECT_ONE); // true
 
 ![update][update]
 
-`4.0.3` Type variable `Type` default value is set to `object`.
+`4.0.3`: Type variable `Type` default value is set to `object`.
 
 Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
 The function uses [`hasOwnProperty`][hasownproperty] [`Object`][object] method to finds enumerable and non-enumerable [`Key`][key] as `string`, `number`, `symbol` unlike `Object.keys()` but it can't find accessor descriptor property unlike `in` operator which can.
@@ -1136,7 +1136,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ![update][update]
 
-`4.0.3` Type variable `Type` default value is set to `object`.
+`4.0.3`: Type variable `Type` default value is set to `object`.
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 

--- a/README.md
+++ b/README.md
@@ -1927,7 +1927,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
 
-`4.0.3`: Type variable `Obj` default value is not set to cause of it always being picked from the `value`.
+`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ const resultCallback: ResultCallback = (result: boolean, value?: any): boolean =
 | result    | `boolean` | A `boolean` type value from the result of the check |
 | value     | `any`     | Any type value from the check                       |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` type result from the check |
 
@@ -259,7 +259,7 @@ const areString = (...value: any): boolean => check('string', ...value);
 | :-------- | :---: | :------------------ |
 | ...value  | `any` | Any values to check |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not all the values are an [`Array`][array] |
 
@@ -332,7 +332,7 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return            | Description |
+| Type return            | Description |
 | :--------------------- | :---------- |
 | `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
@@ -366,7 +366,7 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
@@ -434,7 +434,7 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return        | Description |
+| Type return        | Description |
 | :----------------- | :---------- |
 | `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
@@ -472,7 +472,7 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return        | Description |
+| Type return        | Description |
 | :----------------- | :---------- |
 | `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
@@ -522,7 +522,7 @@ const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return      | Description |
+| Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
@@ -555,7 +555,7 @@ const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An `unknown` `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return  | Description |
+| Type return  | Description |
 | :----------- | :---------- |
 | `boolean`    | The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined` |
 
@@ -601,7 +601,7 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
@@ -656,7 +656,7 @@ const isInstance: IsInstance =
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return      | Description |
+| Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
@@ -694,7 +694,7 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return    | Description |
+| Type return    | Description |
 | :------------- | :---------- |
 | `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
@@ -735,7 +735,7 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
@@ -782,7 +782,7 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -804,7 +804,7 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
@@ -858,7 +858,7 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -919,7 +919,7 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-[ Type return    | Description |
+| Type return    | Description |
 | :------------- | :---------- |
 | `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
@@ -1018,7 +1018,7 @@ const isObjectKey: IsObjectKey =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
@@ -1165,7 +1165,7 @@ const isObjectKeyIn: IsObjectKeyIn =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
@@ -1301,7 +1301,7 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
@@ -1321,7 +1321,7 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
@@ -1341,7 +1341,7 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
@@ -1361,7 +1361,7 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
@@ -1404,7 +1404,7 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return  | Description |
+| Type return  | Description |
 | :----------- | :---------- |
 | `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
@@ -1426,7 +1426,7 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return          | Description |
+| Type return          | Description |
 | :------------------- | :---------- |
 | `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
@@ -1471,7 +1471,7 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` |
 
@@ -1491,7 +1491,7 @@ const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined` |
 
@@ -1511,7 +1511,7 @@ const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback =
 | value     | `unknown` | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `function` |
 
@@ -1531,7 +1531,7 @@ const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `null` |
 
@@ -1556,7 +1556,7 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `number` |
 
@@ -1576,7 +1576,7 @@ const isNotString: IsNotString = (value: unknown, callback: ResultCallback = res
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `string` |
 
@@ -1596,7 +1596,7 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `undefined` |
 

--- a/README.md
+++ b/README.md
@@ -325,16 +325,16 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Type`         | `any`         | A generic variable to returned check `value is Array<Type>` |
+| `Type`         | `any`         | A generic variable to the return type `value` is `Array<Type>` |
 
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return            | Description |
-| :--------------------- | :---------- |
-| `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
+| Type return              | Description |
+| :----------------------- | :---------- |
+| `value` is `Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
 ```typescript
 // Example usage
@@ -366,9 +366,9 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
 ```typescript
 // Example usage
@@ -400,9 +400,9 @@ const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallb
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return        | Description |
-| :----------------- | :---------- |
-| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
+| Type return         | Description |
+| :------------------- | :---------- |
+| `value` is `boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -434,9 +434,9 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return        | Description |
-| :----------------- | :---------- |
-| `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
+| Type return          | Description |
+| :------------------- | :---------- |
+| `value` is `Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -472,9 +472,9 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return        | Description |
-| :----------------- | :---------- |
-| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
+| Type return          | Description |
+| :------------------- | :---------- |
+| `value` is `boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
 ```typescript
 // Example usage
@@ -515,16 +515,16 @@ const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Class`        | `Function`    | A generic variable to returned check `value is Class` |
+| `Class`        | `Function`    | A generic variable to the return type `value` is `Class` |
 
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return      | Description |
-| :--------------- | :---------- |
-| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
+| Type return        | Description |
+| :----------------- | :---------- |
+| `value` is `Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
 ```typescript
 // Example usage
@@ -599,9 +599,9 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
 ```typescript
 // Example usage
@@ -627,7 +627,7 @@ isFunction(() => 5); // true
 
 `4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
-`4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
+`4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value` is `Constructor<Class>`.
 
 Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
 
@@ -646,7 +646,7 @@ const isInstance: IsInstance =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Class`        |               | A generic variable to returned check `value is Constructor<Class>` |
+| `Class`        |               | A generic variable to the return type `value` is `Constructor<Class>` |
 
 | Parameter | Type                                                            | Description                                |
 | :-------- | :-------------------------------------------------------------: | :----------------------------------------- |
@@ -654,9 +654,9 @@ const isInstance: IsInstance =
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return      | Description |
-| :--------------- | :---------- |
-| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
+| Type return        | Description |
+| :----------------- | :---------- |
+| `value` is `Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
 ```typescript
 // Example usage
@@ -692,9 +692,9 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return    | Description |
-| :------------- | :---------- |
-| `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
+| Type return      | Description |
+| :--------------- | :---------- |
+| `value` is `Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
 ```typescript
 // Example usage
@@ -733,9 +733,9 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
 ```typescript
 // Example usage
@@ -780,9 +780,9 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 [Example usage on playground][is-number] | [How to detect a `number` type][detect-number]
 
@@ -802,9 +802,9 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
 ```typescript
 // Example usage
@@ -856,9 +856,9 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 ```typescript
 // Example usage
@@ -913,15 +913,15 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Obj`          | `object`      | A generic variable to returned check `value is Obj` |
+| `Obj`          | `object`      | A generic variable to the return type `value` is `Obj` |
 
 | Parameter | Type   | Description          |
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-| Type return    | Description |
-| :------------- | :---------- |
-| `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
+| Type return      | Description |
+| :--------------- | :---------- |
+| `value` is `Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
 [Example usage on playground][is-object] | [How to detect an `object` type][detect-object]
 
@@ -1010,7 +1010,7 @@ const isObjectKey: IsObjectKey =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Type`         | `object`      | A generic variable to returned check `value is Type` |
+| `Type`         | `object`      | A generic variable to the return type `value` is `Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -1018,9 +1018,9 @@ const isObjectKey: IsObjectKey =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
 ```typescript
 // Example usage
@@ -1157,7 +1157,7 @@ const isObjectKeyIn: IsObjectKeyIn =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Type`         | `object`      | A generic variable to returned check `value is Type` |
+| `Type`         | `object`      | A generic variable to the return type `value` is `Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -1165,9 +1165,9 @@ const isObjectKeyIn: IsObjectKeyIn =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
 ```typescript
 import { isObjectKeyIn } from '@angular-package/type';
@@ -1301,9 +1301,9 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
 ----
 
@@ -1321,9 +1321,9 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
 ----
 
@@ -1341,9 +1341,9 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
 ----
 
@@ -1361,9 +1361,9 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
 [Example usage on playground][is-symbol] | [How to detect `symbol` type][detect-symbol]
 
@@ -1404,9 +1404,9 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return  | Description |
-| :----------- | :---------- |
-| `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
+| Type return    | Description |
+| :------------- | :---------- |
+| `value` is `T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
 [Example usage on playground][is-type]
 
@@ -1426,9 +1426,9 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return          | Description |
-| :------------------- | :---------- |
-| `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
+| Type return            | Description |
+| :--------------------- | :---------- |
+| `value` is `undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
 [Example usage on playground][is-undefined] | [How to detect `undefined` type][detect-undefined]
 
@@ -1676,7 +1676,9 @@ const guardArray: GuardArray = <Type>(value: Array<Type>, callback?: ResultCallb
 | value     | `Array<Type>`                      | A generic `Type` `Array` `value` to guard  |
 | callback? | [`ResultCallback`][resultcallback] | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] of a generic `Type`.
+| Type return   | Description |
+| :------------ | :---------- |
+| `Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] of a generic `Type` |
 
 [Example usage on playground][guard-array]
 
@@ -1696,7 +1698,9 @@ const guardBigInt: GuardBigInt = (value: bigint, callback?: ResultCallback): val
 | value     | `bigint`                            | A `bigint` type `value` to guard |
 | callback? | [`ResultCallback`][resultcallback]  | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `bigint`.
+| Type return | Description |
+| :---------- | :---------- |
+| `bigint`    | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
 ----
 
@@ -1709,18 +1713,22 @@ const guardBoolean: GuardBoolean = <B extends AnyBoolean>(value: B, callback?: R
   isBoolean(value, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `B` extends [`AnyBoolean`](#anyboolean) | From the `value` | A `B` variable from the `value` to the return type `value` is `B` |
+
 | Parameter | Type                                    | Description                                          |
 | :-------- | :-------------------------------------: | :--------------------------------------------------- |
 | value     | `B` extends [`AnyBoolean`](#anyboolean) | An [`AnyBoolean`](#anyboolean) type `value` to guard |
 | callback? | [`ResultCallback`][resultcallback]      | An Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] object.
+| Type return    | Description |
+| :------------- | :---------- |
+| `value` is `B` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] object |
 
 ----
 
 ### guardClass
-
-![new][new]
 
 Use `guardClass()` or `guard.is.class()` to guard the `value` to be a generic `Class` type of [`class`][classes].
 
@@ -1728,6 +1736,10 @@ Use `guardClass()` or `guard.is.class()` to guard the `value` to be a generic `C
 const guardClass: GuardClass = <Class>(value: Class, callback?: ResultCallback): value is Class =>
   isClass<Class>(value, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Class`       | From the `value` | A `Class` variable from the `value` to the return type `value` is `Class` |
 
 | Parameter | Type                               | Description                             |
 | :-------- | :--------------------------------: | :-------------------------------------- |
@@ -1790,14 +1802,16 @@ guardClass<Class>(FUNCTION); // type error
 
 ### guardDefined
 
-![new][new]
-
 Use `guardDefined()` or `guard.is.defined()` to guard the `value` to be defined.
 
 ```typescript
 const guardDefined: GuardDefined = <Type>(value: Type, callback?: ResultCallback): value is Defined<Type> =>
   isDefined(value, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Type`        | From the `value` | A generic `Type` variable from the `value` to the return type `value` is [`Defined<Type>`][defined] |
 
 | Parameter | Type                                    | Description                                          |
 | :-------- | :-------------------------------------: | :--------------------------------------------------- |
@@ -1809,8 +1823,6 @@ The **return value** is A `boolean` indicating whether or not the `value` is def
 ----
 
 ### guardFunction
-
-![update][update]
 
 `4.0.0`: The function denies [`classes`][classes] in check cause of updated [`isFunction()`](#isfunction).
 
@@ -1834,8 +1846,6 @@ The **return value** is a `boolean` indicating whether or not the `value` is a [
 
 ### guardInstance
 
-![update][update]
-
 `4.0.0`: The function uses an updated [`isInstance()`](#isinstance) function that uses [`isClass()`](#isclass).
 
 Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
@@ -1844,6 +1854,10 @@ Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `ob
 const guardInstance: GuardInstance = <Obj>(value: Obj, instance: Constructor<Obj>, callback?: ResultCallback): value is Obj =>
   isInstance<Obj>(value, instance, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Obj`         | From the `value` | A `Obj` variable from the `value` to the return type `value` is `Obj` |
 
 | Parameter | Type                               | Description                                          |
 | :-------- | :--------------------------------: | :--------------------------------------------------- |
@@ -1900,6 +1914,10 @@ const guardNumber: GuardNumber = <N extends AnyNumber>(value: N, callback?: Resu
   isNumber(value, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `N` extends [`AnyNumber`](#anynumber)   | From the `value` | A `N` variable from the `value` to the return type `value` is `N` |
+
 | Parameter | Type                                  | Description                          |
 |---------- | :-----------------------------------: | :----------------------------------- |
 | value     | `N` extends [`AnyNumber`](#anynumber) | An `AnyNumber` type `value` to guard |
@@ -1913,16 +1931,18 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 ### guardObject
 
-![update][update]
-
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 
 ```typescript
-const guardObject: GuardObject = <Obj = object>(value: Obj, callback?: ResultCallback): value is Obj =>
+const guardObject: GuardObject = <Obj>(value: Obj, callback?: ResultCallback): value is Obj =>
   isObject<Obj>(value, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Obj`         | From the `value` | A `Obj` variable from the `value` to the return type `value` is `Obj` |
 
 | Parameter | Type                               | Description                           |
 | :-------- | :--------------------------------: | :------------------------------------ |
@@ -1937,8 +1957,6 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ### guardObjectKey
 
-![update][update]
-
 `4.0.0`: The function uses [`isObjectKey`](#isobjectkey) function to check the `value` and has [`callback`](#resultcallback) as optional instead of the [`guardObject`](#guardobject).
 
 `4.0.1`: Fix guards the `key` by changing its type to `keyof Obj` instead of just a [`Key`][key].
@@ -1947,9 +1965,13 @@ Use `guardObjectKey()` or `guard.is.objectKey()` to guard the `value` to be an `
 
 ```typescript
 const guardObjectKey: GuardObjectKey =
-  <Obj = object>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback): value is Obj =>
+  <Obj>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback): value is Obj =>
     isObjectKey<Obj>(value, key, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Obj`         | From the `value` | A `Obj` variable from the `value` to the return type `value` is `Obj` |
 
 | Parameter   | Type                               | Description                                                            |
 | :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
@@ -1963,35 +1985,9 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ----
 
-### guardObjectKeys
-
-![new][new]
-
-Use `guardObjectKeys()` or `guard.is.objectKeys()` to guard the `value` to be an `object` of a generic `Obj` with some of its own specified `keys`.
-
-```typescript
-const guardObjectKeys: GuardObjectKeys =
-  <Obj = object>(value: Obj, ...keys: (keyof Obj | Array<keyof Obj>)[]): value is Obj =>
-    isObjectKeys<Obj>(value, ...keys);
-```
-
-| Parameter   | Type                               | Description                                                            |
-| :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
-| value       | `Obj`                              | A generic `Obj` type `value` that contains the `keys` to guard         |
-| ...keys     | `(keyof Obj | Array<keyof Obj>)[]` | A rest parameter single key of `Obj` or an array of keys of `Obj`, as the name of the property that the `value` contains |
-
-The **return value** is a `boolean` indicating whether or not the `value` is an `object` with some of its own specified `keys`.
-
-```typescript
-// Example usage
-
-```
-
-----
-
 ### guardPrimitive
 
-Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`](#primitive) from a `type` of the [`Primitives`](#primitives).
+Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`][primitive] from a `type` of the [`Primitives`][primitives].
 
 ```typescript
 const guardPrimitive: GuardPrimitive =
@@ -1999,13 +1995,17 @@ const guardPrimitive: GuardPrimitive =
     isPrimitive<Type>(value, type, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `Type` extends [`Primitive`][primitive] | From the `value` | Guarded with [`Primitive`][primitive] type `Type` variable from the `value` to the return type `value` is `Type` |
+
 | Parameter   | Type                                     | Description                         |
 | :---------- | :--------------------------------------: | :---------------------------------- |
-| value       | `Type` extends [`Primitive`](#primitive) | A `Primitive` type `value` to guard |
-| type        | [`Primitives`](#primitives)              | A `string` type from the [`Primitives`](#primitives) to check the `value` |
+| value       | `Type` extends [`Primitive`][primitive] | A `Primitive` type `value` to guard |
+| type        | [`Primitives`][primitives]              | A `string` type from the [`Primitives`][primitives] to check the `value` |
 | callback?   | [`ResultCallback`][resultcallback]       | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is the [`Primitive`](#primitive) from the `type`.
+The **return value** is a `boolean` indicating whether or not the `value` is the [`Primitive`][primitive] from the `type`.
 
 [Example usage on playground][guard-primitive]
 
@@ -2020,12 +2020,16 @@ const guardString: GuardString = <S extends AnyString>(value: S, callback?: Resu
   isString(value, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `S` extends [`AnyString`](#anystring)   | From the `value` | A `S` variable from the `value` to the return type `value` is `S` |
+
 | Parameter   | Type                                  | Description                          |
 |-------------| :-----------------------------------: | :----------------------------------- |
 | value       | `S` extends [`AnyString`](#anystring) | An `AnyString` type `value` to guard |
 | callback?   | [`ResultCallback`][resultcallback]    | An Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object.
+The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] instance.
 
 [Example usage on playground][guard-string]
 
@@ -2057,6 +2061,10 @@ Use `guardType()` or `guard.is.type()` to guard the `value` to be the [`Type`][t
 const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback?: ResultCallback): value is T  =>
   isType<T>(value, type, callback);
 ```
+
+| Type variable                 | Default value    | Description |
+| :---------------------------- | :--------------- | :---------- |
+| `T` extends [`Type`][type] | From the `value` | Guarded with [`Type`][type] type `T` variable from the `value` to the return type `value` is `T` |
 
 | Parameter | Type                               | Description                                        |
 | :-------- | :--------------------------------: | :------------------------------------------------- |

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -210,12 +210,14 @@ Default function to handle `callback`.
 const resultCallback: ResultCallback = (result: boolean, value?: any): boolean => result;
 ```
 
-| Parameter | Type      | Description                             |
-| :-------- | :-------: | :-------------------------------------- |
-| result    | `boolean` | A `boolean` type value from the result of the check   |
-| value     | `any`     | Any type value from the check |
+| Parameter | Type      | Description                                         |
+| :-------- | :-------: | :-------------------------------------------------- |
+| result    | `boolean` | A `boolean` type value from the result of the check |
+| value     | `any`     | Any type value from the check                       |
 
-The **return value** is a `boolean` type result from the check.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` type result from the check |
 
 Custom function to handle `callback`.
 
@@ -257,7 +259,9 @@ const areString = (...value: any): boolean => check('string', ...value);
 | :-------- | :---: | :------------------ |
 | ...value  | `any` | Any values to check |
 
-The **return value** is a `boolean` indicating whether or not all the values are an `Array`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not all the values are an [`Array`][array] |
 
 [Example usage on playground][are-string]
 
@@ -302,10 +306,14 @@ const is: Is = {
 
 ### isArray
 
+![update][update]
+
+`4.1.0`: Type variable `Class` default value is set to `any`.
+
 Use `isArray()` or `is.array()` to check if **any** `value` is an [`Array`][array], [`Array`][array] instance, and `object` type.
 
 ```typescript
-const isArray: IsArray = <Type>(value: any, callback: ResultCallback = resultCallback): value is Array<Type> =>
+const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = resultCallback): value is Array<Type> =>
   callback(
     typeOf(value) === 'array' &&
     Array.isArray(value) === true &&
@@ -315,12 +323,18 @@ const isArray: IsArray = <Type>(value: any, callback: ResultCallback = resultCal
   );
 ```
 
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Type`         | `any`         | A generic variable to returned check `value is Array<Type>` |
+
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array].
+| Return value           | Description |
+| :--------------------- | :---------- |
+| `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
 ```typescript
 // Example usage
@@ -352,7 +366,9 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `bigint`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
 ```typescript
 // Example usage
@@ -384,7 +400,9 @@ const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallb
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `boolean`.
+| Return value       | Description |
+| :----------------- | :---------- |
+| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -416,7 +434,9 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance.
+| Return value       | Description |
+| :----------------- | :---------- |
+| `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -452,7 +472,9 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type.
+| Return value       | Description |
+| :----------------- | :---------- |
+| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
 ```typescript
 // Example usage
@@ -470,12 +492,14 @@ isBooleanType(BOOLEAN_INSTANCE); // false
 
 ### isClass
 
-![new][new]
+![update][update]
+
+`4.1.0`: Type variable `Class` default value is set to [`Function`][function].
 
 Use `isClass()` or `is.class()` to check if **any** `value` is a `function` type, an instance of [`Function`][function] and [`Object`][object] as a generic `Class` type of [`class`][classes].
 
 ```typescript
-const isClass: IsClass = <Class>(value: any, callback: ResultCallback = resultCallback): value is Class =>
+const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback = resultCallback): value is Class =>
   callback(
     (
       typeOf(value) === 'function' &&
@@ -484,17 +508,23 @@ const isClass: IsClass = <Class>(value: any, callback: ResultCallback = resultCa
       value instanceof Object === true
     ) ?
       /class/.test(Function.prototype.toString.call(value).slice(0, 5))
-    : false,
+      : false,
     value
   );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Class`        | `Function`    | A generic variable to returned check `value is Class` |
 
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `class`.
+| Return value     | Description |
+| :--------------- | :---------- |
+| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
 ```typescript
 // Example usage
@@ -525,7 +555,9 @@ const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An `unknown` `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined`.
+| Return value | Description |
+| :----------- | :---------- |
+| `boolean`    | The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined` |
 
 ```typescript
 // Example usage
@@ -559,7 +591,7 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
       value instanceof Object === true
     ) ?
       /class/.test(Function.prototype.toString.call(value).slice(0, 5)) === false
-    : false,
+      : false,
     value
   );
 ```
@@ -569,7 +601,9 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `function`.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
 ```typescript
 // Example usage
@@ -595,23 +629,26 @@ isFunction(() => 5); // true
 
 `4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
+`4.1.0`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
+
 Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
 
 ```typescript
-const isInstance: IsInstance = <Obj>(
-    value: any,
-    className: Constructor<Obj>,
-    callback: ResultCallback = resultCallback
-  ): value is Obj =>
+const isInstance: IsInstance =
+  <Class>(value: any, className: Constructor<Class>, callback: ResultCallback = resultCallback): value is Constructor<Class> =>
     callback(
-      isObject<Obj>(value) ?
+      isObject<Class>(value) ?
         isClass(className) ?
           value instanceof className === true
-        : false
-      : false,
+          : false
+        : false,
       value
     );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Class`        |               | A generic variable to returned check `value is Constructor<Class>` |
 
 | Parameter | Type                                                            | Description                                |
 | :-------- | :-------------------------------------------------------------: | :----------------------------------------- |
@@ -619,7 +656,9 @@ const isInstance: IsInstance = <Obj>(
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Obj`.
+| Return value     | Description |
+| :--------------- | :---------- |
+| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
 ```typescript
 // Example usage
@@ -655,7 +694,9 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key].
+| Return value   | Description |
+| :------------- | :---------- |
+| `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
 ```typescript
 // Example usage
@@ -694,7 +735,9 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is `null`.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
 ```typescript
 // Example usage
@@ -739,7 +782,9 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `number`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 [Example usage on playground][is-number] | [How to detect a `number` type][detect-number]
 
@@ -759,7 +804,9 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
 ```typescript
 // Example usage
@@ -811,7 +858,9 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `number`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 ```typescript
 // Example usage
@@ -862,11 +911,17 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
   callback(typeOf(value) === 'object' && typeof value === 'object' && value instanceof Object === true, value);
 ```
 
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Obj`          | `object`      | A generic variable to returned check `value is Obj` |
+
 | Parameter | Type   | Description          |
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `object`.
+| Return value   | Description |
+| :------------- | :---------- |
+| `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
 [Example usage on playground][is-object] | [How to detect an `object` type][detect-object]
 
@@ -931,26 +986,31 @@ isObject(OBJECT_ONE); // true
 
 ### isObjectKey
 
+![update][update]
+
+`4.1.0` Type variable `Type` default value is set to `object`.
+
 Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
 The function uses [`hasOwnProperty`][hasownproperty] [`Object`][object] method to finds enumerable and non-enumerable [`Key`][key] as `string`, `number`, `symbol` unlike `Object.keys()` but it can't find accessor descriptor property unlike `in` operator which can.
 
 ```typescript
-const isObjectKey: IsObjectKey = <Type = object>(
-  value: any,
-  key: Key | Key[],
-  callback: ResultCallback = resultCallback
-): value is Type =>
-  callback(
-    isObject<Type>(value) ?
-      isArray(key) ?
-        key.every(k => isKey(k) ? ({}).hasOwnProperty.call(value, k) === true : false)
-      : isKey(key) ?
-          ({}).hasOwnProperty.call(value, key)
-        : false
-    : false,
-    value
-  );
+const isObjectKey: IsObjectKey =
+  <Type = object>(value: any, key: Key | Key[], callback: ResultCallback = resultCallback): value is Type =>
+    callback(
+      isObject<Type>(value) ?
+        isArray(key) ?
+          key.every(k => isKey(k) ? ({}).hasOwnProperty.call(value, k) === true : false)
+          : isKey(key) ?
+            ({}).hasOwnProperty.call(value, key)
+            : false
+        : false,
+      value
+    );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Type`         | `object`      | A generic variable to returned check `value is Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -958,7 +1018,9 @@ const isObjectKey: IsObjectKey = <Type = object>(
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
 ```typescript
 // Example usage
@@ -1072,25 +1134,30 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ### isObjectKeyIn
 
+![update][update]
+
+`4.1.0` Type variable `Type` default value is set to `object`.
+
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
 ```typescript
-const isObjectKeyIn: IsObjectKeyIn = <Type = object>(
-  value: any,
-  key: Key | Key[],
-  callback: ResultCallback = resultCallback
-): value is Type =>
-  callback(
-    isObject<Type>(value) ?
-      isArray(key) ?
-        key.every(k => isKey(k) ? k in value : false)
-      : isKey(key) ?
-          key in value
-        : false
-    : false,
-    value
-  );
+const isObjectKeyIn: IsObjectKeyIn =
+  <Type = object>(value: any, key: Key | Key[], callback: ResultCallback = resultCallback): value is Type =>
+    callback(
+      isObject<Type>(value) ?
+        isArray(key) ?
+          key.every(k => isKey(k) ? k in value : false)
+          : isKey(key) ?
+            key in value
+            : false
+        : false,
+      value
+    );
 ```
+
+| Type variable  | Default value | Description |
+| :------------- | :------------ | :---------- |
+| `Type`         | `object`      | A generic variable to returned check `value is Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -1098,7 +1165,9 @@ const isObjectKeyIn: IsObjectKeyIn = <Type = object>(
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys.
+| Return value    | Description |
+| :-------------- | :---------- |
+| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
 ```typescript
 import { isObjectKeyIn } from '@angular-package/type';
@@ -1232,7 +1301,9 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
 ----
 
@@ -1250,7 +1321,9 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
 ----
 
@@ -1268,7 +1341,9 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `string` type.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
 ----
 
@@ -1286,7 +1361,9 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `symbol`.
+| Return value      | Description |
+| :---------------- | :---------- |
+| `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
 [Example usage on playground][is-symbol] | [How to detect `symbol` type][detect-symbol]
 
@@ -1327,7 +1404,9 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types).
+| Return value | Description |
+| :----------- | :---------- |
+| `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
 [Example usage on playground][is-type]
 
@@ -1347,7 +1426,9 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is `undefined`.
+| Return value         | Description |
+| :------------------- | :---------- |
+| `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
 [Example usage on playground][is-undefined] | [How to detect `undefined` type][detect-undefined]
 
@@ -1390,7 +1471,9 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` |
 
 ----
 
@@ -1408,7 +1491,9 @@ const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined` |
 
 ----
 
@@ -1426,7 +1511,9 @@ const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback =
 | value     | `unknown` | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `function`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `function` |
 
 ----
 
@@ -1444,7 +1531,9 @@ const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not `null`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `null` |
 
 ----
 
@@ -1467,7 +1556,9 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `number`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `number` |
 
 ----
 
@@ -1485,7 +1576,9 @@ const isNotString: IsNotString = (value: unknown, callback: ResultCallback = res
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `string`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `string` |
 
 ----
 
@@ -1503,7 +1596,9 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not `undefined`.
+| Return value  | Description |
+| :------------ | :---------- |
+| `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `undefined` |
 
 ```typescript
 // Example usage with the problem
@@ -1859,12 +1954,38 @@ const guardObjectKey: GuardObjectKey =
 | Parameter   | Type                               | Description                                                            |
 | :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
 | value       | `Obj`                              | A generic `Obj` type `value` that contains the `key` to guard          |
-| key         | `keyof Obj` \| `(keyof Obj)[]`     | A key of `Obj` or an array key of `Obj` type as the name of the property that the `value` contains |
+| key         | `keyof Obj` \| `(keyof Obj)[]`     | A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains |
 | callback?   | [`ResultCallback`][resultcallback] | An Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an `object` of a generic `Obj` containing the `key`.
 
 [Example usage on playground][guard-object-key]
+
+----
+
+### guardObjectKeys
+
+![new][new]
+
+Use `guardObjectKeys()` or `guard.is.objectKeys()` to guard the `value` to be an `object` of a generic `Obj` with some of its own specified `keys`.
+
+```typescript
+const guardObjectKeys: GuardObjectKeys =
+  <Obj = object>(value: Obj, ...keys: (keyof Obj | Array<keyof Obj>)[]): value is Obj =>
+    isObjectKeys<Obj>(value, ...keys);
+```
+
+| Parameter   | Type                               | Description                                                            |
+| :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
+| value       | `Obj`                              | A generic `Obj` type `value` that contains the `keys` to guard         |
+| ...keys     | `(keyof Obj | Array<keyof Obj>)[]` | A rest parameter single key of `Obj` or an array of keys of `Obj`, as the name of the property that the `value` contains |
+
+The **return value** is a `boolean` indicating whether or not the `value` is an `object` with some of its own specified `keys`.
+
+```typescript
+// Example usage
+
+```
 
 ----
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -1927,7 +1927,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
 
-`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
+`4.0.3`: Fix type variable `Obj` default value is set to cause of it always being picked from the `value`.
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 
@@ -1959,7 +1959,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 `4.0.1`: Fix guards the `key` by changing its type to `keyof Obj` instead of just a [`Key`][key].
 
-`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
+`4.0.3`: Fix type variable `Obj` default value is set to cause of it always being picked from the `value`.
 
 Use `guardObjectKey()` or `guard.is.objectKey()` to guard the `value` to be an `object` of a generic `Obj` type that contains the `key`.
 
@@ -1987,7 +1987,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ### guardPrimitive
 
-Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`][primitive] from a `type` of the [`Primitives`][primitives].
+Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`][primitive] from a `type` of the [`Primitives`](#primitives).
 
 ```typescript
 const guardPrimitive: GuardPrimitive =
@@ -1995,14 +1995,14 @@ const guardPrimitive: GuardPrimitive =
     isPrimitive<Type>(value, type, callback);
 ```
 
-| Type variable                           | Default value    | Description |
-| :-------------------------------------- | :--------------- | :---------- |
-| `Type` extends [`Primitive`][primitive] | From the `value` | Guarded with [`Primitive`][primitive] type `Type` variable from the `value` to the return type `value` is `Type` |
+| Type variable                            | Default value    | Description |
+| :--------------------------------------- | :--------------- | :---------- |
+| `Type` extends [`Primitive`](#primitive) | From the `value` | Guarded with [`Primitive`](#primitive) type `Type` variable from the `value` to the return type `value` is `Type` |
 
 | Parameter   | Type                                     | Description                         |
 | :---------- | :--------------------------------------: | :---------------------------------- |
-| value       | `Type` extends [`Primitive`][primitive] | A `Primitive` type `value` to guard |
-| type        | [`Primitives`][primitives]              | A `string` type from the [`Primitives`][primitives] to check the `value` |
+| value       | `Type` extends [`Primitive`](#primitive) | A `Primitive` type `value` to guard |
+| type        | [`Primitives`](#primitives)              | A `string` type from the [`Primitives`](#primitives) to check the `value` |
 | callback?   | [`ResultCallback`][resultcallback]       | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is the [`Primitive`][primitive] from the `type`.
@@ -2062,8 +2062,8 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
   isType<T>(value, type, callback);
 ```
 
-| Type variable                 | Default value    | Description |
-| :---------------------------- | :--------------- | :---------- |
+| Type variable              | Default value    | Description |
+| :------------------------- | :--------------- | :---------- |
 | `T` extends [`Type`][type] | From the `value` | Guarded with [`Type`][type] type `T` variable from the `value` to the return type `value` is `T` |
 
 | Parameter | Type                               | Description                                        |

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -625,11 +625,11 @@ isFunction(() => 5); // true
 
 ![update][update]
 
-`4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
+`4.0.0`: The function uses [`isClass()`](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
 `4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value` is `Constructor<Class>`.
 
-Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
+Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor<Class>`](#constructor) type.
 
 ```typescript
 const isInstance: IsInstance =
@@ -651,7 +651,7 @@ const isInstance: IsInstance =
 | Parameter | Type                                                            | Description                                |
 | :-------- | :-------------------------------------------------------------: | :----------------------------------------- |
 | value     | `any`                                                           | Any `value` to compare with the `instance` |
-| instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
+| instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor<Obj>`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 | Type return        | Description |
@@ -1393,7 +1393,7 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | Parameter | Type                                                            | Description                                         |
 | :-------- | :-------------------------------------------------------------: | :-------------------------------------------------- |
 | value     | `any`                                                           | Any `value` to check if its type is from the `type` |
-| type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
+| type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor<T>` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 | Type return    | Description |
@@ -1840,7 +1840,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is a [
 
 `4.0.0`: The function uses an updated [`isInstance()`](#isinstance) function that uses [`isClass()`](#isclass).
 
-Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
+Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `object` of a generic `Obj` type equal to an `instance` of [`Constructor<Obj>`](#constructor) type.
 
 ```typescript
 const guardInstance: GuardInstance = <Obj>(value: Obj, instance: Constructor<Obj>, callback?: ResultCallback): value is Obj =>
@@ -2069,7 +2069,7 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
 | Parameter | Type                               | Description                                        |
 | :-------- | :--------------------------------: | :------------------------------------------------- |
 | value     | `T` extends [`Type`][type]         | A [`Type`][type] `value` to guard with the `type` |
-| type      | [`Types<T>`](#types)               | A `string` or generic [`Constructor`](#constructor) type from the [`Types`](#types) to check the `value` |
+| type      | [`Types<T>`](#types)               | A `string` or generic [`Constructor<T>`](#constructor) type from the [`Types`](#types) to check the `value` |
 | callback? | [`ResultCallback`][resultcallback] | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
 The **return value** is a `boolean` indicating whether or not the `value` is a `type` from the [`Types`](#types).

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -898,11 +898,7 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 ### isObject
 
-![update][update]
-
 `4.0.0`: The function no longer checks the `key` but has `callback` instead. Use [`isObjectKeyIn`](#isobjectkeyin) or [`isObjectKey`](#isobjectkey) to check object with the [`Key`][key] .
-
-`4.0.3`: Type  variable `Obj`  default value is set to `object`.
 
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
@@ -1133,10 +1129,6 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 ----
 
 ### isObjectKeyIn
-
-![update][update]
-
-`4.0.3`: Type variable `Type` default value is set to `object`.
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
@@ -1931,7 +1923,11 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 ### guardObject
 
+![update][update]
+
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
+
+`4.0.3`: Type variable `Obj` default value is not set to cause of it always being picked from the `value`.
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 
@@ -1957,9 +1953,13 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ### guardObjectKey
 
+![update][update]
+
 `4.0.0`: The function uses [`isObjectKey`](#isobjectkey) function to check the `value` and has [`callback`](#resultcallback) as optional instead of the [`guardObject`](#guardobject).
 
 `4.0.1`: Fix guards the `key` by changing its type to `keyof Obj` instead of just a [`Key`][key].
+
+`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
 
 Use `guardObjectKey()` or `guard.is.objectKey()` to guard the `value` to be an `object` of a generic `Obj` type that contains the `key`.
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -215,7 +215,7 @@ const resultCallback: ResultCallback = (result: boolean, value?: any): boolean =
 | result    | `boolean` | A `boolean` type value from the result of the check |
 | value     | `any`     | Any type value from the check                       |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` type result from the check |
 
@@ -259,7 +259,7 @@ const areString = (...value: any): boolean => check('string', ...value);
 | :-------- | :---: | :------------------ |
 | ...value  | `any` | Any values to check |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not all the values are an [`Array`][array] |
 
@@ -308,7 +308,7 @@ const is: Is = {
 
 ![update][update]
 
-`4.1.0`: Type variable `Class` default value is set to `any`.
+`4.0.3`: Type variable `Class` default value is set to `any`.
 
 Use `isArray()` or `is.array()` to check if **any** `value` is an [`Array`][array], [`Array`][array] instance, and `object` type.
 
@@ -332,7 +332,7 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value           | Description |
+[ Type return            | Description |
 | :--------------------- | :---------- |
 | `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
@@ -366,7 +366,7 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
@@ -400,7 +400,7 @@ const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallb
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value       | Description |
+| Type return        | Description |
 | :----------------- | :---------- |
 | `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
 
@@ -434,7 +434,7 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value       | Description |
+[ Type return        | Description |
 | :----------------- | :---------- |
 | `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
@@ -472,7 +472,7 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value       | Description |
+[ Type return        | Description |
 | :----------------- | :---------- |
 | `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
@@ -494,7 +494,7 @@ isBooleanType(BOOLEAN_INSTANCE); // false
 
 ![update][update]
 
-`4.1.0`: Type variable `Class` default value is set to [`Function`][function].
+`4.0.3`: Type variable `Class` default value is set to [`Function`][function].
 
 Use `isClass()` or `is.class()` to check if **any** `value` is a `function` type, an instance of [`Function`][function] and [`Object`][object] as a generic `Class` type of [`class`][classes].
 
@@ -522,7 +522,7 @@ const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value     | Description |
+[ Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
@@ -555,7 +555,7 @@ const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An `unknown` `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value | Description |
+[ Type return  | Description |
 | :----------- | :---------- |
 | `boolean`    | The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined` |
 
@@ -601,7 +601,7 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
@@ -629,7 +629,7 @@ isFunction(() => 5); // true
 
 `4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
-`4.1.0`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
+`4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
 
 Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
 
@@ -656,7 +656,7 @@ const isInstance: IsInstance =
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value     | Description |
+[ Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
@@ -694,7 +694,7 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value   | Description |
+[ Type return    | Description |
 | :------------- | :---------- |
 | `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
@@ -735,7 +735,7 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
@@ -782,7 +782,7 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -804,7 +804,7 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
@@ -858,7 +858,7 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -919,7 +919,7 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-| Return value   | Description |
+[ Type return    | Description |
 | :------------- | :---------- |
 | `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
@@ -988,7 +988,7 @@ isObject(OBJECT_ONE); // true
 
 ![update][update]
 
-`4.1.0` Type variable `Type` default value is set to `object`.
+`4.0.3` Type variable `Type` default value is set to `object`.
 
 Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
 The function uses [`hasOwnProperty`][hasownproperty] [`Object`][object] method to finds enumerable and non-enumerable [`Key`][key] as `string`, `number`, `symbol` unlike `Object.keys()` but it can't find accessor descriptor property unlike `in` operator which can.
@@ -1018,7 +1018,7 @@ const isObjectKey: IsObjectKey =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
@@ -1136,7 +1136,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ![update][update]
 
-`4.1.0` Type variable `Type` default value is set to `object`.
+`4.0.3` Type variable `Type` default value is set to `object`.
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 
@@ -1165,7 +1165,7 @@ const isObjectKeyIn: IsObjectKeyIn =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value    | Description |
+[ Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
@@ -1301,7 +1301,7 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
@@ -1321,7 +1321,7 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
@@ -1341,7 +1341,7 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
@@ -1361,7 +1361,7 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value      | Description |
+[ Type return       | Description |
 | :---------------- | :---------- |
 | `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
@@ -1404,7 +1404,7 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value | Description |
+[ Type return  | Description |
 | :----------- | :---------- |
 | `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
@@ -1426,7 +1426,7 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value         | Description |
+[ Type return          | Description |
 | :------------------- | :---------- |
 | `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
@@ -1471,7 +1471,7 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` |
 
@@ -1491,7 +1491,7 @@ const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined` |
 
@@ -1511,7 +1511,7 @@ const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback =
 | value     | `unknown` | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `function` |
 
@@ -1531,7 +1531,7 @@ const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `null` |
 
@@ -1556,7 +1556,7 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `number` |
 
@@ -1576,7 +1576,7 @@ const isNotString: IsNotString = (value: unknown, callback: ResultCallback = res
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `string` |
 
@@ -1596,7 +1596,7 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Return value  | Description |
+[ Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `undefined` |
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -575,8 +575,6 @@ isDefined(defined); // false
 
 ### isFunction
 
-![update][update]
-
 `4.0.0`: The function denies [classes][classes] in check to differ from classes.
 
 Use `isFunction()` or `is.function()` to check if **any** `value` is a `function` type, an instance of [`Function`][function] and [`Object`][object].
@@ -904,6 +902,8 @@ isNumberType(NUMBER_NEW_INSTANCE); // false
 
 `4.0.0`: The function no longer checks the `key` but has `callback` instead. Use [`isObjectKeyIn`](#isobjectkeyin) or [`isObjectKey`](#isobjectkey) to check object with the [`Key`][key] .
 
+`4.0.3`: Type  variable `Obj`  default value is set to `object`.
+
 Use `isObject()` or `is.object()` to check if **any** `value` is an `object` of a generic `Obj` type and [`Object`][object] instance.
 
 ```typescript
@@ -988,7 +988,7 @@ isObject(OBJECT_ONE); // true
 
 ![update][update]
 
-`4.0.3` Type variable `Type` default value is set to `object`.
+`4.0.3`: Type variable `Type` default value is set to `object`.
 
 Use `isObjectKey()` or `is.objectKey()` to check if **any** `value` is an `object` with its own specified keys of the [`Key`][key].
 The function uses [`hasOwnProperty`][hasownproperty] [`Object`][object] method to finds enumerable and non-enumerable [`Key`][key] as `string`, `number`, `symbol` unlike `Object.keys()` but it can't find accessor descriptor property unlike `in` operator which can.
@@ -1136,7 +1136,7 @@ isObjectKey(CLASS, [SYMBOL_NUMBER, SYMBOL_STRING]); // false
 
 ![update][update]
 
-`4.0.3` Type variable `Type` default value is set to `object`.
+`4.0.3`: Type variable `Type` default value is set to `object`.
 
 Use `isObjectKeyIn()` or `is.objectKeyIn()` to check if **any** `value` is an [`Object`][object] with the `key` of the [`Key`][key] type by using the `in` operator. The function uses operator [`in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) to find the key.
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -1927,7 +1927,7 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
 
-`4.0.3`: Type variable `Obj` default value is not set to cause of it always being picked from the `value`.
+`4.0.3`: Fix type variable `Obj` default value is not set to cause of it always being picked from the `value`.
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -215,7 +215,7 @@ const resultCallback: ResultCallback = (result: boolean, value?: any): boolean =
 | result    | `boolean` | A `boolean` type value from the result of the check |
 | value     | `any`     | Any type value from the check                       |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` type result from the check |
 
@@ -259,7 +259,7 @@ const areString = (...value: any): boolean => check('string', ...value);
 | :-------- | :---: | :------------------ |
 | ...value  | `any` | Any values to check |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not all the values are an [`Array`][array] |
 
@@ -332,7 +332,7 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return            | Description |
+| Type return            | Description |
 | :--------------------- | :---------- |
 | `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
@@ -366,7 +366,7 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
@@ -434,7 +434,7 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return        | Description |
+| Type return        | Description |
 | :----------------- | :---------- |
 | `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
@@ -472,7 +472,7 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return        | Description |
+| Type return        | Description |
 | :----------------- | :---------- |
 | `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
@@ -522,7 +522,7 @@ const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return      | Description |
+| Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
@@ -555,7 +555,7 @@ const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An `unknown` `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return  | Description |
+| Type return  | Description |
 | :----------- | :---------- |
 | `boolean`    | The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined` |
 
@@ -601,7 +601,7 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
@@ -656,7 +656,7 @@ const isInstance: IsInstance =
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return      | Description |
+| Type return      | Description |
 | :--------------- | :---------- |
 | `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
@@ -694,7 +694,7 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return    | Description |
+| Type return    | Description |
 | :------------- | :---------- |
 | `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
@@ -735,7 +735,7 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
@@ -782,7 +782,7 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -804,7 +804,7 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
@@ -858,7 +858,7 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
@@ -919,7 +919,7 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-[ Type return    | Description |
+| Type return    | Description |
 | :------------- | :---------- |
 | `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
@@ -1018,7 +1018,7 @@ const isObjectKey: IsObjectKey =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
@@ -1165,7 +1165,7 @@ const isObjectKeyIn: IsObjectKeyIn =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return     | Description |
+| Type return     | Description |
 | :-------------- | :---------- |
 | `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
@@ -1301,7 +1301,7 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
@@ -1321,7 +1321,7 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
@@ -1341,7 +1341,7 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
@@ -1361,7 +1361,7 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return       | Description |
+| Type return       | Description |
 | :---------------- | :---------- |
 | `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
@@ -1404,7 +1404,7 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return  | Description |
+| Type return  | Description |
 | :----------- | :---------- |
 | `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
@@ -1426,7 +1426,7 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return          | Description |
+| Type return          | Description |
 | :------------------- | :---------- |
 | `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
@@ -1471,7 +1471,7 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` |
 
@@ -1491,7 +1491,7 @@ const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = r
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined` |
 
@@ -1511,7 +1511,7 @@ const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback =
 | value     | `unknown` | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `function` |
 
@@ -1531,7 +1531,7 @@ const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `null` |
 
@@ -1556,7 +1556,7 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `number` |
 
@@ -1576,7 +1576,7 @@ const isNotString: IsNotString = (value: unknown, callback: ResultCallback = res
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not a `string` |
 
@@ -1596,7 +1596,7 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 | value     | `unknown`                                                       | An unknown `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-[ Type return   | Description |
+| Type return   | Description |
 | :------------ | :---------- |
 | `boolean`     | The **return value** is a `boolean` indicating whether or not the `value` is not `undefined` |
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -325,16 +325,16 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Type`         | `any`         | A generic variable to returned check `value is Array<Type>` |
+| `Type`         | `any`         | A generic variable to the return type `value` is `Array<Type>` |
 
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return            | Description |
-| :--------------------- | :---------- |
-| `value is Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
+| Type return              | Description |
+| :----------------------- | :---------- |
+| `value` is `Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] |
 
 ```typescript
 // Example usage
@@ -366,9 +366,9 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `bigint` | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
 ```typescript
 // Example usage
@@ -400,9 +400,9 @@ const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallb
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return        | Description |
-| :----------------- | :---------- |
-| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
+| Type return         | Description |
+| :------------------- | :---------- |
+| `value` is `boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -434,9 +434,9 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 | value     | `any` | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return        | Description |
-| :----------------- | :---------- |
-| `value is Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
+| Type return          | Description |
+| :------------------- | :---------- |
+| `value` is `Boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Boolean`][boolean] instance |
 
 ```typescript
 // Example usage
@@ -472,9 +472,9 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return        | Description |
-| :----------------- | :---------- |
-| `value is boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
+| Type return          | Description |
+| :------------------- | :---------- |
+| `value` is `boolean` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type |
 
 ```typescript
 // Example usage
@@ -515,16 +515,16 @@ const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Class`        | `Function`    | A generic variable to returned check `value is Class` |
+| `Class`        | `Function`    | A generic variable to the return type `value` is `Class` |
 
 | Parameter | Type                                                            | Description          |
 | :-------- | :-------------------------------------------------------------: | :------------------- |
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return      | Description |
-| :--------------- | :---------- |
-| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
+| Type return        | Description |
+| :----------------- | :---------- |
+| `value` is `Class` | The **return value** is a `boolean` indicating whether or not the `value` is a [`class`][classes] |
 
 ```typescript
 // Example usage
@@ -599,9 +599,9 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `Func` | The **return value** is a `boolean` indicating whether or not the `value` is a `function` |
 
 ```typescript
 // Example usage
@@ -627,7 +627,7 @@ isFunction(() => 5); // true
 
 `4.0.0`: The function uses [isClass](#isclass) in check to check the `className` instead of [`isFunction()`](#isfunction).
 
-`4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value is Constructor<Class>`.
+`4.0.3`: Type variable name `Obj` changes to `Class` and the type result to `value` is `Constructor<Class>`.
 
 Use `isInstance()` or `is.instance()` to check if **any** value is an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
 
@@ -646,7 +646,7 @@ const isInstance: IsInstance =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Class`        |               | A generic variable to returned check `value is Constructor<Class>` |
+| `Class`        |               | A generic variable to the return type `value` is `Constructor<Class>` |
 
 | Parameter | Type                                                            | Description                                |
 | :-------- | :-------------------------------------------------------------: | :----------------------------------------- |
@@ -654,9 +654,9 @@ const isInstance: IsInstance =
 | instance  | [`Constructor<Obj>`](#constructor)                              | A generic `Obj` [`Constructor`](#constructor) type to create an `instance` to compare with the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return      | Description |
-| :--------------- | :---------- |
-| `value is Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
+| Type return        | Description |
+| :----------------- | :---------- |
+| `value` is `Class` | The **return value** is a `boolean` indicating whether or not the `value` is an `instance` of a generic `Class` |
 
 ```typescript
 // Example usage
@@ -692,9 +692,9 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return    | Description |
-| :------------- | :---------- |
-| `value is Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
+| Type return      | Description |
+| :--------------- | :---------- |
+| `value` is `Key` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Key`][key] |
 
 ```typescript
 // Example usage
@@ -733,9 +733,9 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `null` | The **return value** is a `boolean` indicating whether or not the `value` is `null` |
 
 ```typescript
 // Example usage
@@ -780,9 +780,9 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 [Example usage on playground][is-number] | [How to detect a `number` type][detect-number]
 
@@ -802,9 +802,9 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `Number` | The **return value** is a `boolean` indicating whether or not the `value` is a [`Number`][Number] instance |
 
 ```typescript
 // Example usage
@@ -856,9 +856,9 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `number` | The **return value** is a `boolean` indicating whether or not the `value` is a `number` |
 
 ```typescript
 // Example usage
@@ -913,15 +913,15 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Obj`          | `object`      | A generic variable to returned check `value is Obj` |
+| `Obj`          | `object`      | A generic variable to the return type `value` is `Obj` |
 
 | Parameter | Type   | Description          |
 | :-------- | :----: | :------------------- |
 | value     | `any`  | Any `value` to check |
 
-| Type return    | Description |
-| :------------- | :---------- |
-| `value is Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
+| Type return      | Description |
+| :--------------- | :---------- |
+| `value` is `Obj` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` |
 
 [Example usage on playground][is-object] | [How to detect an `object` type][detect-object]
 
@@ -1010,7 +1010,7 @@ const isObjectKey: IsObjectKey =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Type`         | `object`      | A generic variable to returned check `value is Type` |
+| `Type`         | `object`      | A generic variable to the return type `value` is `Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -1018,9 +1018,9 @@ const isObjectKey: IsObjectKey =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with its own specified keys |
 
 ```typescript
 // Example usage
@@ -1157,7 +1157,7 @@ const isObjectKeyIn: IsObjectKeyIn =
 
 | Type variable  | Default value | Description |
 | :------------- | :------------ | :---------- |
-| `Type`         | `object`      | A generic variable to returned check `value is Type` |
+| `Type`         | `object`      | A generic variable to the return type `value` is `Type` |
 
 | Parameter | Type                                                            | Description                                           |
 | :-------- | :-------------------------------------------------------------: | :---------------------------------------------------- |
@@ -1165,9 +1165,9 @@ const isObjectKeyIn: IsObjectKeyIn =
 | key       | [`Key`][key] \| [`Key[]`][key]                                  | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return     | Description |
-| :-------------- | :---------- |
-| `value is Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
+| Type return       | Description |
+| :---------------- | :---------- |
+| `value` is `Type` | The **return value** is a `boolean` indicating whether or not the `value` is an `object` with the keys |
 
 ```typescript
 import { isObjectKeyIn } from '@angular-package/type';
@@ -1301,9 +1301,9 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                               | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]  | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object |
 
 ----
 
@@ -1321,9 +1321,9 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `String` | The **return value** is a `boolean` indicating whether or not the `value` is a [`String`][string] instance |
 
 ----
 
@@ -1341,9 +1341,9 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `string` | The **return value** is a `boolean` indicating whether or not the `value` is a `string` type |
 
 ----
 
@@ -1361,9 +1361,9 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return       | Description |
-| :---------------- | :---------- |
-| `value is symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
+| Type return         | Description |
+| :------------------ | :---------- |
+| `value` is `symbol` | The **return value** is a `boolean` indicating whether or not the `value` is a `symbol` |
 
 [Example usage on playground][is-symbol] | [How to detect `symbol` type][detect-symbol]
 
@@ -1404,9 +1404,9 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 | type      | [`Types<T>`](#types)                                            | A `string` or generic `Constructor` type from the [`Types`](#types) to check the `value` |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return  | Description |
-| :----------- | :---------- |
-| `value is T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
+| Type return    | Description |
+| :------------- | :---------- |
+| `value` is `T` | The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types) |
 
 [Example usage on playground][is-type]
 
@@ -1426,9 +1426,9 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 | value     | `any`                                                           | Any `value` to check |
 | callback  | [`ResultCallback`][resultcallback]=[`resultCallback`][callback] | [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-| Type return          | Description |
-| :------------------- | :---------- |
-| `value is undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
+| Type return            | Description |
+| :--------------------- | :---------- |
+| `value` is `undefined` | The **return value** is a `boolean` indicating whether or not the `value` is `undefined` |
 
 [Example usage on playground][is-undefined] | [How to detect `undefined` type][detect-undefined]
 
@@ -1676,7 +1676,9 @@ const guardArray: GuardArray = <Type>(value: Array<Type>, callback?: ResultCallb
 | value     | `Array<Type>`                      | A generic `Type` `Array` `value` to guard  |
 | callback? | [`ResultCallback`][resultcallback] | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] of a generic `Type`.
+| Type return   | Description |
+| :------------ | :---------- |
+| `Array<Type>` | The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array] of a generic `Type` |
 
 [Example usage on playground][guard-array]
 
@@ -1696,7 +1698,9 @@ const guardBigInt: GuardBigInt = (value: bigint, callback?: ResultCallback): val
 | value     | `bigint`                            | A `bigint` type `value` to guard |
 | callback? | [`ResultCallback`][resultcallback]  | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `bigint`.
+| Type return | Description |
+| :---------- | :---------- |
+| `bigint`    | The **return value** is a `boolean` indicating whether or not the `value` is a `bigint` |
 
 ----
 
@@ -1709,18 +1713,22 @@ const guardBoolean: GuardBoolean = <B extends AnyBoolean>(value: B, callback?: R
   isBoolean(value, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `B` extends [`AnyBoolean`](#anyboolean) | From the `value` | A `B` variable from the `value` to the return type `value` is `B` |
+
 | Parameter | Type                                    | Description                                          |
 | :-------- | :-------------------------------------: | :--------------------------------------------------- |
 | value     | `B` extends [`AnyBoolean`](#anyboolean) | An [`AnyBoolean`](#anyboolean) type `value` to guard |
 | callback? | [`ResultCallback`][resultcallback]      | An Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] object.
+| Type return    | Description |
+| :------------- | :---------- |
+| `value` is `B` | The **return value** is a `boolean` indicating whether or not the `value` is a `boolean` type or [`Boolean`][boolean] object |
 
 ----
 
 ### guardClass
-
-![new][new]
 
 Use `guardClass()` or `guard.is.class()` to guard the `value` to be a generic `Class` type of [`class`][classes].
 
@@ -1728,6 +1736,10 @@ Use `guardClass()` or `guard.is.class()` to guard the `value` to be a generic `C
 const guardClass: GuardClass = <Class>(value: Class, callback?: ResultCallback): value is Class =>
   isClass<Class>(value, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Class`       | From the `value` | A `Class` variable from the `value` to the return type `value` is `Class` |
 
 | Parameter | Type                               | Description                             |
 | :-------- | :--------------------------------: | :-------------------------------------- |
@@ -1790,14 +1802,16 @@ guardClass<Class>(FUNCTION); // type error
 
 ### guardDefined
 
-![new][new]
-
 Use `guardDefined()` or `guard.is.defined()` to guard the `value` to be defined.
 
 ```typescript
 const guardDefined: GuardDefined = <Type>(value: Type, callback?: ResultCallback): value is Defined<Type> =>
   isDefined(value, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Type`        | From the `value` | A generic `Type` variable from the `value` to the return type `value` is [`Defined<Type>`][defined] |
 
 | Parameter | Type                                    | Description                                          |
 | :-------- | :-------------------------------------: | :--------------------------------------------------- |
@@ -1809,8 +1823,6 @@ The **return value** is A `boolean` indicating whether or not the `value` is def
 ----
 
 ### guardFunction
-
-![update][update]
 
 `4.0.0`: The function denies [`classes`][classes] in check cause of updated [`isFunction()`](#isfunction).
 
@@ -1834,8 +1846,6 @@ The **return value** is a `boolean` indicating whether or not the `value` is a [
 
 ### guardInstance
 
-![update][update]
-
 `4.0.0`: The function uses an updated [`isInstance()`](#isinstance) function that uses [`isClass()`](#isclass).
 
 Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `object` of a generic `Obj` type equal to an `instance` of [`Constructor`](#constructor) type.
@@ -1844,6 +1854,10 @@ Use `guardInstance()` or `guard.is.instance()` to guard the `value` to be an `ob
 const guardInstance: GuardInstance = <Obj>(value: Obj, instance: Constructor<Obj>, callback?: ResultCallback): value is Obj =>
   isInstance<Obj>(value, instance, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Obj`         | From the `value` | A `Obj` variable from the `value` to the return type `value` is `Obj` |
 
 | Parameter | Type                               | Description                                          |
 | :-------- | :--------------------------------: | :--------------------------------------------------- |
@@ -1900,6 +1914,10 @@ const guardNumber: GuardNumber = <N extends AnyNumber>(value: N, callback?: Resu
   isNumber(value, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `N` extends [`AnyNumber`](#anynumber)   | From the `value` | A `N` variable from the `value` to the return type `value` is `N` |
+
 | Parameter | Type                                  | Description                          |
 |---------- | :-----------------------------------: | :----------------------------------- |
 | value     | `N` extends [`AnyNumber`](#anynumber) | An `AnyNumber` type `value` to guard |
@@ -1913,16 +1931,18 @@ The **return value** is a `boolean` indicating whether or not the `value` is a `
 
 ### guardObject
 
-![update][update]
-
 `4.0.0`: The function has a properly working callback cause of the updated [`isObject`](#isobject).
 
 Use `guardObject()` or `guard.is.object()` to guard the `value` to be an `object` of a generic `Obj` type.
 
 ```typescript
-const guardObject: GuardObject = <Obj = object>(value: Obj, callback?: ResultCallback): value is Obj =>
+const guardObject: GuardObject = <Obj>(value: Obj, callback?: ResultCallback): value is Obj =>
   isObject<Obj>(value, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Obj`         | From the `value` | A `Obj` variable from the `value` to the return type `value` is `Obj` |
 
 | Parameter | Type                               | Description                           |
 | :-------- | :--------------------------------: | :------------------------------------ |
@@ -1937,8 +1957,6 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ### guardObjectKey
 
-![update][update]
-
 `4.0.0`: The function uses [`isObjectKey`](#isobjectkey) function to check the `value` and has [`callback`](#resultcallback) as optional instead of the [`guardObject`](#guardobject).
 
 `4.0.1`: Fix guards the `key` by changing its type to `keyof Obj` instead of just a [`Key`][key].
@@ -1947,9 +1965,13 @@ Use `guardObjectKey()` or `guard.is.objectKey()` to guard the `value` to be an `
 
 ```typescript
 const guardObjectKey: GuardObjectKey =
-  <Obj = object>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback): value is Obj =>
+  <Obj>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback): value is Obj =>
     isObjectKey<Obj>(value, key, callback);
 ```
+
+| Type variable | Default value    | Description |
+| :------------ | :--------------- | :---------- |
+| `Obj`         | From the `value` | A `Obj` variable from the `value` to the return type `value` is `Obj` |
 
 | Parameter   | Type                               | Description                                                            |
 | :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
@@ -1963,35 +1985,9 @@ The **return value** is a `boolean` indicating whether or not the `value` is an 
 
 ----
 
-### guardObjectKeys
-
-![new][new]
-
-Use `guardObjectKeys()` or `guard.is.objectKeys()` to guard the `value` to be an `object` of a generic `Obj` with some of its own specified `keys`.
-
-```typescript
-const guardObjectKeys: GuardObjectKeys =
-  <Obj = object>(value: Obj, ...keys: (keyof Obj | Array<keyof Obj>)[]): value is Obj =>
-    isObjectKeys<Obj>(value, ...keys);
-```
-
-| Parameter   | Type                               | Description                                                            |
-| :---------- | :--------------------------------: | :--------------------------------------------------------------------- |
-| value       | `Obj`                              | A generic `Obj` type `value` that contains the `keys` to guard         |
-| ...keys     | `(keyof Obj | Array<keyof Obj>)[]` | A rest parameter single key of `Obj` or an array of keys of `Obj`, as the name of the property that the `value` contains |
-
-The **return value** is a `boolean` indicating whether or not the `value` is an `object` with some of its own specified `keys`.
-
-```typescript
-// Example usage
-
-```
-
-----
-
 ### guardPrimitive
 
-Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`](#primitive) from a `type` of the [`Primitives`](#primitives).
+Use `guardPrimitive()` or `guard.is.primitive()` to guard the `value` to be the [`Primitive`][primitive] from a `type` of the [`Primitives`][primitives].
 
 ```typescript
 const guardPrimitive: GuardPrimitive =
@@ -1999,13 +1995,17 @@ const guardPrimitive: GuardPrimitive =
     isPrimitive<Type>(value, type, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `Type` extends [`Primitive`][primitive] | From the `value` | Guarded with [`Primitive`][primitive] type `Type` variable from the `value` to the return type `value` is `Type` |
+
 | Parameter   | Type                                     | Description                         |
 | :---------- | :--------------------------------------: | :---------------------------------- |
-| value       | `Type` extends [`Primitive`](#primitive) | A `Primitive` type `value` to guard |
-| type        | [`Primitives`](#primitives)              | A `string` type from the [`Primitives`](#primitives) to check the `value` |
+| value       | `Type` extends [`Primitive`][primitive] | A `Primitive` type `value` to guard |
+| type        | [`Primitives`][primitives]              | A `string` type from the [`Primitives`][primitives] to check the `value` |
 | callback?   | [`ResultCallback`][resultcallback]       | Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is the [`Primitive`](#primitive) from the `type`.
+The **return value** is a `boolean` indicating whether or not the `value` is the [`Primitive`][primitive] from the `type`.
 
 [Example usage on playground][guard-primitive]
 
@@ -2020,12 +2020,16 @@ const guardString: GuardString = <S extends AnyString>(value: S, callback?: Resu
   isString(value, callback);
 ```
 
+| Type variable                           | Default value    | Description |
+| :-------------------------------------- | :--------------- | :---------- |
+| `S` extends [`AnyString`](#anystring)   | From the `value` | A `S` variable from the `value` to the return type `value` is `S` |
+
 | Parameter   | Type                                  | Description                          |
 |-------------| :-----------------------------------: | :----------------------------------- |
 | value       | `S` extends [`AnyString`](#anystring) | An `AnyString` type `value` to guard |
 | callback?   | [`ResultCallback`][resultcallback]    | An Optional [`ResultCallback`][resultcallback] function to handle result before returns eg. to throw an `Error` |
 
-The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] object.
+The **return value** is a `boolean` indicating whether or not the `value` is a `string` type or [`String`][string] instance.
 
 [Example usage on playground][guard-string]
 
@@ -2057,6 +2061,10 @@ Use `guardType()` or `guard.is.type()` to guard the `value` to be the [`Type`][t
 const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback?: ResultCallback): value is T  =>
   isType<T>(value, type, callback);
 ```
+
+| Type variable                 | Default value    | Description |
+| :---------------------------- | :--------------- | :---------- |
+| `T` extends [`Type`][type] | From the `value` | Guarded with [`Type`][type] type `T` variable from the `value` to the return type `value` is `T` |
 
 | Parameter | Type                               | Description                                        |
 | :-------- | :--------------------------------: | :------------------------------------------------- |

--- a/packages/type/package-lock.json
+++ b/packages/type/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@angular-package/type",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@angular-package/type",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-package/type",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Common types, type guards and type checkers.",
   "author": "Angular Package <angular-package@wvvw.dev> (https://wvvw.dev)",
   "homepage": "https://github.com/angular-package/type#readme",

--- a/packages/type/src/guard/lib/guard-object-key.func.ts
+++ b/packages/type/src/guard/lib/guard-object-key.func.ts
@@ -6,7 +6,7 @@ import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be an `object` of a generic `Obj` type that contains the `key`.
  * @param value A generic `Obj` type `value` that contains the `key` to guard.
- * @param key A key of `Obj` or an array key of `Obj` type as the name of the property that the `value` contains.
+ * @param key A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains.
  * @param callback An optional `ResultCallback` function to handle result before returns.
  * @returns A `boolean` indicating whether or not the `value` is an `object` of a generic `Obj` containing the `key`.
  */

--- a/packages/type/src/guard/lib/guard-object-key.func.ts
+++ b/packages/type/src/guard/lib/guard-object-key.func.ts
@@ -11,5 +11,5 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @returns A `boolean` indicating whether or not the `value` is an `object` of a generic `Obj` containing the `key`.
  */
 export const guardObjectKey: GuardObjectKey =
-  <Obj = object>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback): value is Obj =>
+  <Obj>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback): value is Obj =>
     isObjectKey<Obj>(value, key, callback);

--- a/packages/type/src/guard/lib/guard-object.func.ts
+++ b/packages/type/src/guard/lib/guard-object.func.ts
@@ -9,5 +9,5 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @param callback An optional `ResultCallback` function to handle result before returns.
  * @returns A `boolean` indicating whether or not the `value` is an `object` of a generic `Obj`.
  */
-export const guardObject: GuardObject = <Obj = object>(value: Obj, callback?: ResultCallback): value is Obj =>
+export const guardObject: GuardObject = <Obj>(value: Obj, callback?: ResultCallback): value is Obj =>
   isObject<Obj>(value, callback);

--- a/packages/type/src/guard/type/guard-object-key.type.ts
+++ b/packages/type/src/guard/type/guard-object-key.type.ts
@@ -1,4 +1,4 @@
 import { ResultCallback } from '../../type/result-callback.type';
-export type GuardObjectKey = <Obj = object>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback) => value is Obj;
+export type GuardObjectKey = <Obj>(value: Obj, key: keyof Obj | (keyof Obj)[], callback?: ResultCallback) => value is Obj;
 
 

--- a/packages/type/src/guard/type/guard-object.type.ts
+++ b/packages/type/src/guard/type/guard-object.type.ts
@@ -1,2 +1,2 @@
 import { ResultCallback } from '../../type/result-callback.type';
-export type GuardObject = <Obj = object>(value: Obj, callback?: ResultCallback) => value is Obj;
+export type GuardObject = <Obj>(value: Obj, callback?: ResultCallback) => value is Obj;

--- a/packages/type/src/is/lib/is-array.func.ts
+++ b/packages/type/src/is/lib/is-array.func.ts
@@ -11,7 +11,7 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @callback `resultCallback`.
  * @returns A `boolean` indicating whether or not the `value` is an `Array`.
  */
-export const isArray: IsArray = <Type>(value: any, callback: ResultCallback = resultCallback): value is Array<Type> =>
+export const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = resultCallback): value is Array<Type> =>
   callback(
     typeOf(value) === 'array' &&
     Array.isArray(value) === true &&

--- a/packages/type/src/is/lib/is-boolean.func.ts
+++ b/packages/type/src/is/lib/is-boolean.func.ts
@@ -11,7 +11,7 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @param value Any `value` to check.
  * @param callback `ResultCallback` function to handle result before returns.
  * @callback `resultCallback`.
- * @returns A `boolean` indicating whether or not the `value` is a `boolean` type or `Boolean` object.
+ * @returns A `boolean` indicating whether or not the `value` is a `boolean` type or `Boolean` instance.
  */
 export const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallback): value is boolean =>
   callback(typeOf(value) === 'boolean' && (isBooleanType(value) || isBooleanObject(value)), value);

--- a/packages/type/src/is/lib/is-class.func.ts
+++ b/packages/type/src/is/lib/is-class.func.ts
@@ -11,7 +11,7 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @callback `resultCallback`.
  * @returns A `boolean` indicating whether or not the `value` is a `class`.
  */
-export const isClass: IsClass = <Class>(value: any, callback: ResultCallback = resultCallback): value is Class =>
+export const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback = resultCallback): value is Class =>
   callback(
     (
       typeOf(value) === 'function' &&
@@ -20,7 +20,6 @@ export const isClass: IsClass = <Class>(value: any, callback: ResultCallback = r
       value instanceof Object === true
     ) ?
       /class/.test(Function.prototype.toString.call(value).slice(0, 5))
-    : false,
+      : false,
     value
   );
-

--- a/packages/type/src/is/lib/is-function.func.ts
+++ b/packages/type/src/is/lib/is-function.func.ts
@@ -21,6 +21,6 @@ export const isFunction: IsFunction = (value: any, callback: ResultCallback = re
       value instanceof Object === true
     ) ?
       /class/.test(Function.prototype.toString.call(value).slice(0, 5)) === false
-    : false,
+      : false,
     value
   );

--- a/packages/type/src/is/lib/is-instance.func.ts
+++ b/packages/type/src/is/lib/is-instance.func.ts
@@ -14,16 +14,13 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @callback `resultCallback`.
  * @returns  A `boolean` indicating whether or not the `value` is an `instance` of a generic `Obj`.
  */
-export const isInstance: IsInstance = <Obj>(
-    value: any,
-    className: Constructor<Obj>,
-    callback: ResultCallback = resultCallback
-  ): value is Obj =>
+export const isInstance: IsInstance =
+  <Class>(value: any, className: Constructor<Class>, callback: ResultCallback = resultCallback): value is Constructor<Class> =>
     callback(
-      isObject<Obj>(value) ?
+      isObject<Class>(value) ?
         isClass(className) ?
           value instanceof className === true
-        : false
-      : false,
+          : false
+        : false,
       value
     );

--- a/packages/type/src/is/lib/is-object-key-in.func.ts
+++ b/packages/type/src/is/lib/is-object-key-in.func.ts
@@ -15,18 +15,15 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @callback `resultCallback`.
  * @returns A `boolean` indicating whether or not the `value` is an `object` with the keys.
  */
-export const isObjectKeyIn: IsObjectKeyIn = <Type = object>(
-  value: any,
-  key: Key | Key[],
-  callback: ResultCallback = resultCallback
-): value is Type =>
-  callback(
-    isObject<Type>(value) ?
-      isArray(key) ?
-        key.every(k => isKey(k) ? k in value : false)
-      : isKey(key) ?
-          key in value
-        : false
-    : false,
-    value
-  );
+export const isObjectKeyIn: IsObjectKeyIn =
+  <Type = object>(value: any, key: Key | Key[], callback: ResultCallback = resultCallback): value is Type =>
+    callback(
+      isObject<Type>(value) ?
+        isArray(key) ?
+          key.every(k => isKey(k) ? k in value : false)
+          : isKey(key) ?
+            key in value
+            : false
+        : false,
+      value
+    );

--- a/packages/type/src/is/lib/is-object-key.func.ts
+++ b/packages/type/src/is/lib/is-object-key.func.ts
@@ -15,18 +15,15 @@ import { ResultCallback } from '../../type/result-callback.type';
  * @callback `resultCallback`.
  * @returns A `boolean` indicating whether or not the `value` is an `object` with its own specified keys.
  */
-export const isObjectKey: IsObjectKey = <Type = object>(
-  value: any,
-  key: Key | Key[],
-  callback: ResultCallback = resultCallback
-): value is Type =>
-  callback(
-    isObject<Type>(value) ?
-      isArray(key) ?
-        key.every(k => isKey(k) ? ({}).hasOwnProperty.call(value, k) === true : false)
-      : isKey(key) ?
-          ({}).hasOwnProperty.call(value, key)
-        : false
-    : false,
-    value
-  );
+export const isObjectKey: IsObjectKey =
+  <Type = object>(value: any, key: Key | Key[], callback: ResultCallback = resultCallback): value is Type =>
+    callback(
+      isObject<Type>(value) ?
+        isArray(key) ?
+          key.every(k => isKey(k) ? ({}).hasOwnProperty.call(value, k) === true : false)
+          : isKey(key) ?
+            ({}).hasOwnProperty.call(value, key)
+            : false
+        : false,
+      value
+    );

--- a/packages/type/src/is/test/is-class.spec.ts
+++ b/packages/type/src/is/test/is-class.spec.ts
@@ -1,0 +1,93 @@
+// Function.
+import { isClass } from '../lib/is-class.func';
+// Variables.
+import { BIGINT, BIGINT_EXPECTATION, BIGINT_INSTANCE } from './variables/big-int.const';
+import { Class, CLASS } from './variables/class.const';
+import { FALSE, TRUE, FALSE_INSTANCE, TRUE_INSTANCE, FALSE_EXPECTATION, TRUE_EXPECTATION } from './variables/boolean.const';
+import { FUNCTION } from './variables/function.const';
+import { NULL } from './variables/null.const';
+import { NUMBER, NUMBER_INSTANCE, NUMBER_NEW_INSTANCE } from './variables/number.const';
+import { OBJECT_ONE, OBJECT_TWO, OBJECT_ONE_NEW, OBJECT_TWO_NEW } from './variables/object.const';
+import { STRING, STRING_INSTANCE, STRING_NEW_INSTANCE } from './variables/string.const';
+import { SYMBOL_NUMBER, SYMBOL_STRING } from './variables/symbol.const';
+import { UNDEFINED } from './variables/undefined.const';
+/**
+ * Checks
+ * ✓ typeOf() === 'function' & typeof === 'function' && instanceof Object === true && instanceof Function === true
+ */
+describe(isClass.name, () => {
+  // Defined.
+  it('is DEFINED', () => expect(isClass).toBeDefined());
+
+  // Checks ...
+  describe(`checks`, () => {
+    it('callback', () => {
+      isClass(Class, (result: boolean, value: any) => {
+        expect(result).toBe(TRUE);
+        expect(value).toEqual(Class);
+        return result;
+      });
+    });
+    // ... arrays.
+    describe(`array`, () => {
+      // it(`${FUNCTION}`, () => expect(isClass(FUNCTION, 'function')).toBe(FALSE));
+      // it(`${Class}`, () => expect(isClass(Class, 'function')).toBe(FALSE));
+    });
+    // ... function.
+    describe(`function`, () => {
+      it(`FUNCTION`, () => expect(isClass(FUNCTION)).toBe(FALSE));
+      it(`Class`, () => expect(isClass(Class)).toBe(TRUE));
+    });
+    // ... objects.
+    describe('object', () => {
+      it(`CLASS`, () => expect(isClass(CLASS)).toBe(FALSE));
+      it(`OBJECT_ONE`, () => expect(isClass(OBJECT_ONE)).toBe(FALSE));
+      it(`OBJECT_TWO`, () => expect(isClass(OBJECT_TWO)).toBe(FALSE));
+      it(`new Object(OBJECT_ONE_NEW})`, () => expect(isClass(OBJECT_ONE_NEW)).toBe(FALSE));
+      it(`new Object(OBJECT_TWO_NEW})`, () => expect(isClass(OBJECT_TWO_NEW)).toBe(FALSE));
+    });
+    // ... primitives.
+    describe(`primitive`, () => {
+      // bigint
+      describe(`bigint`, () => it(`${BIGINT}`, () => expect(isClass(BIGINT)).toBe(FALSE)));
+      // boolean
+      describe(`boolean`, () => {
+        it(`${TRUE}`, () => expect(isClass(TRUE)).toBe(FALSE));
+        it(`${FALSE}`, () => expect(isClass(FALSE)).toBe(FALSE));
+      });
+      // null
+      it(`${NULL}`, () => expect(isClass(NULL)).toBe(FALSE));
+      // number
+      describe(`number`, () => {
+        it(`${NUMBER}`, () => expect(isClass(NUMBER)).toBe(FALSE));
+        it(`Number(${NUMBER})`, () => expect(isClass(NUMBER_INSTANCE)).toBe(FALSE));
+      });
+      // string
+      describe(`string`, () => {
+        it(`${STRING}`, () => expect(isClass(STRING)).toBe(FALSE));
+        it(`String(${STRING})`, () => expect(isClass(STRING_INSTANCE)).toBe(FALSE));
+      });
+      // symbol
+      describe(`symbol`, () => {
+        it(`Symbol(${NUMBER})`, () => expect(isClass(SYMBOL_NUMBER)).toBe(FALSE));
+        it(`Symbol(${STRING})`, () => expect(isClass(SYMBOL_STRING)).toBe(FALSE));
+      });
+      // undefined
+      it(`${UNDEFINED}`, () => expect(isClass(UNDEFINED)).toBe(FALSE));
+      // ... object.
+      describe(`object`, () => {
+        // BigInt
+        describe(`BigInt`, () => it(`${BIGINT_EXPECTATION}`, () => expect(isClass(BIGINT_INSTANCE)).toBe(FALSE)));
+        // Boolean
+        describe(`Boolean`, () => {
+          it(`${TRUE_EXPECTATION}`, () => expect(isClass(TRUE_INSTANCE)).toBe(FALSE));
+          it(`${FALSE_EXPECTATION}`, () => expect(isClass(FALSE_INSTANCE)).toBe(FALSE));
+        });
+        // Number
+        describe(`Number`, () => it(`new Number(${NUMBER})`, () => expect(isClass(NUMBER_NEW_INSTANCE)).toBe(FALSE)));
+        // String
+        describe(`String`, () => it(`new String(${STRING})`, () => expect(isClass(STRING_NEW_INSTANCE)).toBe(FALSE)));
+      });
+    });
+  });
+});

--- a/packages/type/src/is/type/is-array.type.ts
+++ b/packages/type/src/is/type/is-array.type.ts
@@ -1,2 +1,2 @@
 import { ResultCallback } from '../../type/result-callback.type';
-export type IsArray = <Type>(value: any, callback?: ResultCallback) => value is Array<Type>;
+export type IsArray = <Type = any>(value: any, callback?: ResultCallback) => value is Array<Type>;

--- a/packages/type/src/is/type/is-class.type.ts
+++ b/packages/type/src/is/type/is-class.type.ts
@@ -1,2 +1,2 @@
 import { ResultCallback } from '../../type/result-callback.type';
-export type IsClass = <Class>(value: any, callback?: ResultCallback) => value is Class;
+export type IsClass = <Class = Function>(value: any, callback?: ResultCallback) => value is Class;

--- a/packages/type/src/is/type/is-instance.type.ts
+++ b/packages/type/src/is/type/is-instance.type.ts
@@ -1,3 +1,3 @@
 import { Constructor } from '../../type/constructor.type';
 import { ResultCallback } from '../../type/result-callback.type';
-export type IsInstance = <Obj>(value: any, instance: Constructor<Obj>, callback?: ResultCallback) => value is Obj;
+export type IsInstance = <Class>(value: any, instance: Constructor<Class>, callback?: ResultCallback) => value is Constructor<Class>;


### PR DESCRIPTION
* `guardObject()`: remove default value from type variable `Obj` b4cfa83
* `guardObjectKey()`: remove default value from type variable `Obj` 3ef3402
* `isClass()`: 
  * Add tests b7e406d
  * Type variable `Class` default value is set to `Function` 70f4fc2 
* `isArray()`: Type variable `Type` default value is set to any  ac8eba8
* `isInstance()` 7e405ac
  * Type  variable name `Obj` changes to `Class`
  * Type returns `value is Constructor<Class>`

Update README.md