### PR TITLE
4.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,10 +376,10 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -418,10 +418,10 @@ const isBigInt: IsBigInt = (value: any, callback: ResultCallback = resultCallbac
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -460,10 +460,10 @@ const isBoolean: IsBoolean = (value: any, callback: ResultCallback = resultCallb
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -502,10 +502,10 @@ const isBooleanObject: IsBooleanObject = (value: any, callback: ResultCallback =
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -548,10 +548,10 @@ const isBooleanType: IsBooleanType = (value: any, callback: ResultCallback = res
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -604,10 +604,10 @@ const isClass: IsClass = <Class = Function>(value: any, callback: ResultCallback
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -636,25 +636,31 @@ isClass(() => 5); // false
 
 ### isDefined
 
-Use `isDefined()` or `is.defined()` to check if an **unknown** `value` is **not** an `undefined` type and is **not** equal to `undefined`.
+Use `isDefined()` or `is.defined()` to check if a generic `Type` `value` is **not** an `undefined` type and is **not** equal to `undefined`.
 
 ```typescript
-const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
+const isDefined: IsDefined = <Type>(value: Type, callback: ResultCallback = resultCallback): value is Defined<Type> =>
   callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
 ```
 
+**Generic type variables:**
+
+| Name   | Default value    | Description                                                    |
+| :----- | :--------------- | :------------------------------------------------------------- |
+| `Type` | From the `value` | A generic variable to the return type `value is Defined<Type>` |
+
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                     |
+| :------------------------- | :------------------------------ |
+| value: `unknown`           | A generic type `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                         |
-| :-------- | :-------: | :---------------------------------  |
-| `boolean` | `boolean` | The **return type** is a `boolean`  |
+| Returns                  | Type      | Description                         |
+| :----------------------- | :-------: | :---------------------------------  |
+| `value is Defined<Type>` | `boolean` | The **return type** is a `boolean`  |
 
 The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined`
 
@@ -695,10 +701,10 @@ const isFunction: IsFunction = (value: any, callback: ResultCallback = resultCal
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -763,11 +769,11 @@ const isInstance: IsInstance =
 
 **Parameters:**
 
-| Name: `type`                                   | Description                                        |
-| :--------------------------------------------- | :------------------------------------------------- |
-| value: `any`                                   | Any `value` to be an instance of the `constructor` |
-| constructor: [`Constructor<Obj>`][constructor] | A [`class`][ts-classes] or [`function`][ts-function] that specifies the type of the [`Constructor`][constructor] |
-| callback: [`ResultCallback`][resultcallback]   | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                    | Description                                        |
+| :------------------------------ | :------------------------------------------------- |
+| value: `any`                    | Any `value` to be an instance of the `constructor` |
+| constructor: `Constructor<Obj>` | A [`class`][ts-classes] or [`function`][ts-function] that specifies the type of the [`Constructor`][constructor] |
+| callback: `ResultCallback`      | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -827,10 +833,10 @@ const isKey: IsKey = (value: any, callback: ResultCallback = resultCallback): va
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -876,10 +882,10 @@ const isNull: IsNull = (value: any, callback: ResultCallback = resultCallback): 
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- |--------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- |--------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -931,10 +937,10 @@ const isNumber: IsNumber = (value: any, callback: ResultCallback = resultCallbac
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -961,10 +967,10 @@ const isNumberObject: IsNumberObject = (value: any, callback: ResultCallback = r
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1023,10 +1029,10 @@ const isNumberType: IsNumberType = (value: any, callback: ResultCallback = resul
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1091,10 +1097,10 @@ const isObject: IsObject = <Obj = object>(value: any, callback: ResultCallback =
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1195,11 +1201,11 @@ const isObjectKey: IsObjectKey =
 
 **Parameters:**
 
-| Name: `type`                                 | Description                                           |
-| :------------------------------------------- | :---------------------------------------------------- |
-| value: `any`                                 | Any `value` to check if it contains a specified `key` |
-| key: [`Key`][key] \| [`Key[]`][key]          | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                                           |
+| :------------------------- | :---------------------------------------------------- |
+| value: `any`               | Any `value` to check if it contains a specified `key` |
+| key: `Key | Key[]`         | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1348,11 +1354,11 @@ const isObjectKeyIn: IsObjectKeyIn =
 
 **Parameters:**
 
-| Name: `type`                                 | Description                                                                  |
-| :------------------------------------------- | :--------------------------------------------------------------------------- |
-| value: `any`                                 | Any `value` to check if it contains a specified `key`                        |
-| key: [`Key`][key] \| [`Key[]`][key]          | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                                                                  |
+| :------------------------- | :--------------------------------------------------------------------------- |
+| value: `any`               | Any `value` to check if it contains a specified `key`                        |
+| key: `Key | Key[]`         | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1477,10 +1483,10 @@ const isObjectKeys: IsObjectKeys = <Type = object>(
 
 **Parameters:**
 
-| Name: `type`                            | Description                                                                                 |
-| :-------------------------------------- | :------------------------------------------------------------------------------------------ |
-| value: `any`                            | Any `value` to check if it contains **some** of the specified `keys`                        |
-| ...keys: [`Key`][key] \| [`Key[]`][key] | A [rest parameter][function-rest-parameter] single [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| Name: `type`                    | Description                                                                                 |
+| :------------------------------ | :------------------------------------------------------------------------------------------ |
+| value: `any`                    | Any `value` to check if it contains **some** of the specified `keys`                        |
+| ...keys: `(Key | Array<Key>)[]` | A [rest parameter][function-rest-parameter] single [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 
 **Returns:**
 
@@ -1572,11 +1578,11 @@ const isPrimitive: IsPrimitive = <T extends Primitive>(
 
 **Parameters:**
 
-| Name: `type`                                 | Description                                                               |
-| :------------------------------------------- | :------------------------------------------------------------------------ |
-| value: `any`                                 | Any `value` to check if it's a `Primitive` from the `type`                |
-| type: [`Primitives`](#primitives)            | A `string` type from the [`Primitives`](#primitives) to check the `value` |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                                                               |
+| :------------------------- | :------------------------------------------------------------------------ |
+| value: `any`               | Any `value` to check if it's a `Primitive` from the `type`                |
+| type: `Primitives`         | A `string` type from the [`Primitives`](#primitives) to check the `value` |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1603,10 +1609,10 @@ const isString: IsString = (value: any, callback: ResultCallback = resultCallbac
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1629,10 +1635,10 @@ const isStringObject: IsStringObject = (value: any, callback: ResultCallback = r
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1655,10 +1661,10 @@ const isStringType: IsStringType = (value: any, callback: ResultCallback = resul
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1681,10 +1687,10 @@ const isSymbol: IsSymbol = (value: any, callback: ResultCallback = resultCallbac
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1737,11 +1743,11 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 
 **Parameters:**
 
-| Name: `type`                                 | Description                                         |
-| :------------------------------------------- | :-------------------------------------------------- |
-| value: `any`                                 | Any `value` to check if its type is from the `type` |
-| type: [`Types<T>`](#types)                   | A `string` or generic `Constructor<T>` type from the [`Types`](#types) to check the `value` |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                                         |
+| :------------------------- | :-------------------------------------------------- |
+| value: `any`               | Any `value` to check if its type is from the `type` |
+| type: `Types<T>`           | A `string` or generic `Constructor<T>` type from the [`Types`](#types) to check the `value` |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1768,10 +1774,10 @@ const isUndefined: IsUndefined = (value: any, callback: ResultCallback = resultC
 
 **Parameters:**
 
-| Name: `type`                                 | Description          |
-| :------------------------------------------- | :------------------- |
-| value: `any`                                 | Any `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description          |
+| :------------------------- | :------------------- |
+| value: `any`               | Any `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1821,10 +1827,10 @@ const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = r
 
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                 |
+| :------------------------- | :-------------------------- |
+| value: `unknown`           | An unknown `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1847,10 +1853,10 @@ const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = r
 
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                 |
+| :------------------------- | :-------------------------- |
+| value: `unknown`           | An unknown `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1873,10 +1879,10 @@ const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback =
 
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                 |
+| :------------------------- | :-------------------------- |
+| value: `unknown`           | An unknown `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1899,10 +1905,10 @@ const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultC
 
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                 |
+| :------------------------- | :-------------------------- |
+| value: `unknown`           | An unknown `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1930,10 +1936,10 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
 
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                 |
+| :------------------------- | :-------------------------- |
+| value: `unknown`           | An unknown `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1956,10 +1962,10 @@ const isNotString: IsNotString = (value: unknown, callback: ResultCallback = res
 
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                 |
+| :------------------------- | :-------------------------- |
+| value: `unknown`           | An unknown `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -1982,10 +1988,10 @@ const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback
 
 **Parameters:**
 
-| Name: `type`                                 | Description                 |
-| :------------------------------------------- | :-------------------------- |
-| value: `unknown`                             | An unknown `value` to check |
-| callback: [`ResultCallback`][resultcallback] | A function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`               | Description                 |
+| :------------------------- | :-------------------------- |
+| value: `unknown`           | An unknown `value` to check |
+| callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2084,10 +2090,10 @@ const guardArray: GuardArray = <Type>(value: Array<Type>, callback?: ResultCallb
 
 **Parameters:**
 
-| Name: `type`                                  | Description                                                                               |
-| :-------------------------------------------- | :---------------------------------------------------------------------------------------- |
-| value: `Array<Type>`                          | An `Array` of a generic `Type` variable from the `value` to guard                         |
-| callback?: [`ResultCallback`][resultcallback] | An optional function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                               |
+| :-------------------------- | :---------------------------------------------------------------------------------------- |
+| value: `Array<Type>`        | An `Array` of a generic `Type`, by default of type detected from the `value` - to guard   |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2114,10 +2120,10 @@ const guardBigInt: GuardBigInt = (value: bigint, callback?: ResultCallback): val
 
 **Parameters:**
 
-| Name: `type`                                  | Description                      |
-| :-------------------------------------------- | :------------------------------- |
-| value: `bigint`                               | A `bigint` type `value` to guard |
-| callback?: [`ResultCallback`][resultcallback] | An optional function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                      |
+| :-------------------------- | :------------------------------- |
+| value: `bigint`             | A `bigint` type `value` to guard |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2138,16 +2144,16 @@ const guardBoolean: GuardBoolean = <B extends AnyBoolean>(value: B, callback?: R
 
 **Generic type variables:**
 
-| Name                                    | Default value    | Description |
-| :-------------------------------------- | :--------------- | :---------- |
-| `B` extends [`AnyBoolean`](#anyboolean) | From the `value` | Guarded with [`AnyBoolean`](#anyboolean), generic `B` variable from the `value` to the return type `value is B` |
+| Name                   | Default value    | Description |
+| :--------------------- | :--------------- | :---------- |
+| `B extends AnyBoolean` | From the `value` | Guarded with [`AnyBoolean`](#anyboolean), generic `B` variable from the `value` to the return type `value is B` |
 
 **Parameters:**
 
-| Name: `type`                                   | Description                                                   |
-| :--------------------------------------------- | :------------------------------------------------------------ |
-| value: `B` extends [`AnyBoolean`](#anyboolean) | An [`AnyBoolean`](#anyboolean) type from the `value` to guard |
-| callback?: [`ResultCallback`][resultcallback]  | An optional function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                                                        |
+| :-------------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| value: `B`                  | An [`AnyBoolean`](#anyboolean) type `value`, by default of a generic `B` type detected from the `value` - to guard |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error]                          |
 
 **Returns:**
 
@@ -2174,16 +2180,16 @@ const guardClass: GuardClass = <Class extends Function>(value: Class, callback?:
 
 **Generic type variables:**
 
-| Name    | Default value    | Description |
-| :------ | :--------------- | :---------- |
-| `Class` | From the `value` | Guarded with `Function`, generic `Class` variable from the `value` to the return type `value is Class` |
+| Name                     | Default value    | Description |
+| :----------------------- | :--------------- | :---------- |
+| `Class extends Function` | From the `value` | Guarded with [`Function`][ts-function], generic `Class` variable from the `value` to the return type `value is Class` |
 
 **Parameters:**
 
-| Name: `type`                                  | Description                                                                           |
-| :-------------------------------------------- | :------------------------------------------------------------------------------------ |
-| value: `Class`                                | A generic type from the `value` to guard                                              |
-| callback?: [`ResultCallback`][resultcallback] | An optional function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                                                       |
+| :-------------------------- | :---------------------------------------------------------------------------------------------------------------- |
+| value: `Class`              | A [`Function`][ts-function] type `value`, by default of a generic `Class` type detected from the `value` to guard |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error]                         |
 
 **Returns:**
 
@@ -2269,10 +2275,10 @@ const guardDefined: GuardDefined = <Type>(value: Defined<Type>, callback?: Resul
 
 **Parameters:**
 
-| Name: `type`                                  | Description                                                                               |
-| :-------------------------------------------- | :---------------------------------------------------------------------------------------- |
-| value: [`Defined<Type>`][defined]             | A generic type `value` to guard                                                           |
-| callback?: [`ResultCallback`][resultcallback] | An optional function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                                                                  |
+| :-------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| value: `Defined<Type>`      | A generic type `value`, by default of [`Defined<Type>`][defined] type detected from the `value` to guard against `undefined` |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error]                                    |
 
 **Returns:**
 
@@ -2295,10 +2301,10 @@ const guardFunction: GuardFunction = (value: Func, callback?: ResultCallback): v
 
 **Parameters:**
 
-| Name: `type`                                  | Description                                                                               |
-| :-------------------------------------------- | :---------------------------------------------------------------------------------------- |
-| value: [`Func`](#func)                        | A [`Func`](#func) type `value` to guard                                                   |
-| callback?: [`ResultCallback`][resultcallback] | An optional function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                               |
+| :-------------------------- | :---------------------------------------------------------------------------------------- |
+| value: `Func`               | A [`Func`](#func) type `value` to guard                                                   |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2332,17 +2338,17 @@ const guardInstance: GuardInstance =
 
 **Generic type variables:**
 
-| Name  | Default value    | Description                                                                              |
-| :---- | :--------------- | :--------------------------------------------------------------------------------------- |
-| `Obj` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
+| Name                | Default value    | Description                                                                              |
+| :------------------ | :--------------- | :--------------------------------------------------------------------------------------- |
+| `Obj extends objet` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
 
 **Parameters:**
 
-| Name: `type`                                   | Description                                                                  |
-| :--------------------------------------------- | :--------------------------------------------------------------------------- |
-| value: `Obj`                                   | A generic `Obj` type from the `value` to be an instance of the `constructor` |
-| constructor: [`Constructor<Obj>`][constructor] | A [`class`][ts-classes] or [`[function]`][ts-function] that specifies the type of the [`constructor`][constructor] |
-| callback?: [`ResultCallback`][resultcallback]  | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                    | Description                                                                                                                       |
+| :------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
+| value: `Obj`                    | An `object`, by default of a generic `Obj` type detected from the `value` to guard and to check if it's a `constructor` instance  |
+| constructor: `Constructor<Obj>` | A [`class`][ts-classes] or [`[function]`][ts-function] that specifies the type of the [`constructor`][constructor]                |
+| callback?: `ResultCallback`     | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2409,10 +2415,10 @@ const guardKey: GuardKey = (value: Key, callback?: ResultCallback): value is Key
 
 **Parameters:**
 
-| Name: `type`                                  | Description                           |
-| :-------------------------------------------- | :------------------------------------ |
-| value: [`Key`][key]                           | A [`Key`][key] type `value` to guard  |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                           |
+| :-------------------------- | :------------------------------------ |
+| value: `Key`                | A [`Key`][key] type `value` to guard  |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2435,10 +2441,10 @@ const guardNull: GuardNull = (value: null, callback?: ResultCallback): value is 
 
 **Parameters:**
 
-| Name: `type`                                  | Description                    |
-| :-------------------------------------------- | :----------------------------- |
-| value: `null`                                 | A `null` type `value` to guard |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                    |
+| :-------------------------- | :----------------------------- |
+| value: `null`               | A `null` type `value` to guard |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2461,16 +2467,16 @@ const guardNumber: GuardNumber = <N extends AnyNumber>(value: N, callback?: Resu
 
 **Generic type variables:**
 
-| Name                                  | Default value    | Description |
-| :------------------------------------ | :--------------- | :---------- |
-| `N` extends [`AnyNumber`](#anynumber) | From the `value` | Guarded with [`AnyNumber`](#anynumber), `N` variable from the `value` to the return type `value is N` |
+| Name                   | Default value    | Description |
+| :--------------------- | :--------------- | :---------- |
+| `N extends AnyNumber`  | From the `value` | Guarded with [`AnyNumber`](#anynumber), `N` variable from the `value` to the return type `value is N` |
 
 **Parameters:**
 
-| Name: `type`                                  | Description                          |
-| :-------------------------------------------- | :----------------------------------- |
-| value: `N` extends [`AnyNumber`](#anynumber)  | An `AnyNumber` type `value` to guard |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                 | Description                                                                                                                       |
+| :--------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| value: `N`                   | An [`AnyNumber`](#anynumber) type `value`, by default of a generic `N` type detected from the `value` to guard                    |
+| callback?: `ResultCallback`  | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2505,10 +2511,10 @@ const guardObject: GuardObject = <Obj extends object>(value: Obj, callback?: Res
 
 **Parameters:**
 
-| Name: `type`                                  | Description                           |
-| :-------------------------------------------- | :------------------------------------ |
-| value: `Obj`                                  | A generic `Obj` type `value` to guard |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                                |
+| :-------------------------- | :----------------------------------------------------------------------------------------- |
+| value: `Obj`                | An `object` of a generic `Obj` type, by default of type detected from the `value` to guard |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2546,11 +2552,11 @@ const guardObjectKey: GuardObjectKey =
 
 **Parameters:**
 
-| Name: `type`                                  | Description                                                            |
-| :-------------------------------------------- | :--------------------------------------------------------------------- |
-| value: `Obj`                                  | A generic `Obj` type `value` that contains the `key` to guard          |
-| key: `keyof Obj` \| `(keyof Obj)[]`           | A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                     | Description                                                                                                              |
+| :------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| value: `Obj`                     | An `object` of a generic `Obj` type that contains the `key`, by default of type detected from the `value` to guard       |
+| key: `keyof Obj | (keyof Obj)[]` | A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains                   |
+| callback?: `ResultCallback`      | An optional [`ResultCallback`][resultcallback] type to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2591,10 +2597,10 @@ const guardObjectKeys: GuardObjectKeys =
 
 **Parameters:**
 
-| Name: `type`                            | Description                                                            |
-| :-------------------------------------- | :--------------------------------------------------------------------- |
-| value: `Obj`                            | A generic `Obj` type `value` that contains the `key` to guard          |
-| ...keys: `keyof Obj` \| `(keyof Obj)[]` | A [rest parameter][function-rest-parameter] single key of `Obj` or an array of key of `Obj` type as the name of the property that the `value` contains |
+| Name: `type`                         | Description                                                                                                       |
+| :----------------------------------- | :---------------------------------------------------------------------------------------------------------------- |
+| value: `Obj`                         | An object of a generic `Obj` type that contains the `keys`, by default of type detected from the `value` to guard |
+| ...keys: `keyof Obj | (keyof Obj)[]` | A [rest parameter][function-rest-parameter] single key of `Obj` or an array of key of `Obj` type as the name of the property that the `value` contains |
 
 **Returns:**
 
@@ -2670,11 +2676,11 @@ const guardPrimitive: GuardPrimitive =
 
 **Parameters:**
 
-| Name: `type`                                    | Description                                                               |
-| :---------------------------------------------- | :------------------------------------------------------------------------ |
-| value: `Type` extends [`Primitive`](#primitive) | A [`Primitive`](#primitive) type `value` to guard                         |
-| type: [`Primitives`](#primitives)               | A `string` type from the [`Primitives`](#primitives) to check the `value` |
-| callback?: [`ResultCallback`][resultcallback]   | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                                                 |
+| :-------------------------- | :---------------------------------------------------------------------------------------------------------- |
+| value: `Type`               | A [`Primitive`](#primitive) type `value`, by default of a generic `Type` detected from the `value` to guard |
+| type: `Primitives`          | A `string` type from the [`Primitives`](#primitives) to check the `value`                                   |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2707,10 +2713,10 @@ const guardString: GuardString = <S extends AnyString>(value: S, callback?: Resu
 
 **Parameters:**
 
-| Name: `type`                                  | Description                          |
-|---------------------------------------------- | :----------------------------------- |
-| value: `S` extends [`AnyString`](#anystring)  | An `AnyString` type `value` to guard |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                          |
+|---------------------------- | :----------------------------------- |
+| value: `S`                  | An [`AnyString`](#anystring) type `value`, by default of a generic `S` type detected from the `value` to guard           |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2737,10 +2743,10 @@ const guardSymbol: GuardSymbol = (value: symbol, callback?: ResultCallback): val
 
 **Parameters:**
 
-| Name: `type`                                  | Description                      |
-| :-------------------------------------------- | :------------------------------- |
-| value: `symbol`                               | A `symbol` type `value` to guard |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                      |
+| :-------------------------- | :------------------------------- |
+| value: `symbol`             | A `symbol` type `value` to guard |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2769,11 +2775,11 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
 
 **Parameters:**
 
-| Name: `type`                                  | Description                                                                                                           |
-| :-------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
-| value: `T` extends [`Type`][type]             | A [`Type`][type] `value` to guard with the `type`                                                                     |
-| type: [`Types<T>`](#types)                    | A `string` or generic [`Constructor<T>`][constructor] type from the [`Types`](#types) to check the `value`            |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                                                                                                                       |
+| :-------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| value: `T`                  | A [`Type`][type] `value`, by default of a generic `T` type detected from the `value` to guard with the `type`                     |
+| type: `Types<T>`            | A `string` or generic [`Constructor<T>`][constructor] type from the [`Types`](#types) to check the `value`                        |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2800,10 +2806,10 @@ const guardUndefined: GuardUndefined = (value: undefined, callback?: ResultCallb
 
 **Parameters:**
 
-| Name: `type`                                  | Description                          |
-| :-------------------------------------------- | :----------------------------------- |
-| value: `undefined`                            | An `undefined` type `value` to guard |
-| callback?: [`ResultCallback`][resultcallback] | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                | Description                          |
+| :-------------------------- | :----------------------------------- |
+| value: `undefined`          | An `undefined` type `value` to guard |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 

--- a/README.md
+++ b/README.md
@@ -1811,7 +1811,7 @@ const isNot: IsNot = {
 
 ### isNotBoolean
 
-![fix][update]
+![fix][fix]
 
 `4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `boolean` or [`Boolean`][boolean] by changing the `value` type to a generic `Type` and the return type to `value is Never<AnyBoolean, Type>`.
 
@@ -1871,7 +1871,7 @@ isNotBoolean(objectBoolean); // false; return type is `value is never`
 
 ### isNotDefined
 
-![fix][update]
+![fix][fix]
 
 `4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `defined` by changing the `value` type to a generic `Type` and the return type to `value is Undefined<Type>`.
 
@@ -1929,7 +1929,7 @@ isNotDefined(surname); // false; return type is `value is never`
 
 ### isNotFunction
 
-![fix][update]
+![fix][fix]
 
 `4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `function` by changing the `value` type to a generic `Type` and the return type to `value is Never<Func, Type>`.
 
@@ -1988,7 +1988,7 @@ isNotFunction('maybe i am not'); // true; return type is `value is string`
 
 ### isNotNull
 
-![fix][update]
+![fix][fix]
 
 `4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `null` by changing `value` type to a generic `Type` and the return type to `value is Never<null, Type>`.
 
@@ -2041,7 +2041,7 @@ isNotNull(firstName); // return type is `value is never`
 
 ### isNotNumber
 
-![fix][update]
+![fix][fix]
 
 `4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not a `number` or `Number` by changing `value` type to a generic `Type` and the return type to `value is Never<number, Type>`.
 
@@ -2103,7 +2103,7 @@ isNotNumber(objectNumber); // return type is `value is never`
 
 ### isNotString
 
-![fix][update]
+![fix][fix]
 
 `4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not a `string` or [`String`][string] by changing `value` type to a generic `Type` and the return type to `value is Never<string, Type>`.
 
@@ -2165,7 +2165,7 @@ isNotString(objectString); // return type is `value is never`
 
 ### isNotUndefined
 
-![fix][update]
+![fix][fix]
 
 `4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `undefined` by changing `value` type to a generic `Type` and the return type to `value is Defined<Type>`.
 
@@ -3419,6 +3419,7 @@ MIT © angular-package ([license][license])
 [skeleton]: https://github.com/angular-package/skeleton
 
 <!-- Changes -->
+[fix]: https://img.shields.io/badge/-fix-red
 [new]: https://img.shields.io/badge/-new-green
 [update]: https://img.shields.io/badge/-update-red
 

--- a/README.md
+++ b/README.md
@@ -1811,121 +1811,247 @@ const isNot: IsNot = {
 
 ### isNotBoolean
 
-Use `isNotBoolean()` or `is.not.boolean()` to check if an **unknown** `value` is **not** a `boolean` type, **not** equal to `true` or `false` and **not** an instance of a [`Boolean`][boolean].
+![fix][update]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `boolean` or [`Boolean`][boolean] by changing the `value` type to a generic `Type` and the return type to `value is Never<AnyBoolean, Type>`.
+
+Use `isNotBoolean()` or `is.not.boolean()` to check if a generic `Type` `value` is **not** a `boolean` type and **not** an instance of a [`Boolean`][boolean].
 
 ```typescript
-const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
+const isNotBoolean: IsNotBoolean = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<AnyBoolean, Type> =>
   callback(
     typeOf(value) !== 'boolean' &&
     typeof value !== 'boolean' &&
-    value instanceof Boolean === false &&
-    value !== true &&
-    value !== false,
+    value instanceof Boolean === false,
     value
   );
 ```
 
+**Generic type variables:**
+
+| Name   | Default value    | Description                                                                                      |
+| :----- | :--------------- | :----------------------------------------------------------------------------------------------- |
+| `Type` | From the `value` | A generic `Type` variable from the `value` to the return type `value is Never<AnyBoolean, Type>` |
+
 **Parameters:**
 
-| Name: `type`               | Description                 |
-| :------------------------- | :-------------------------- |
-| value: `unknown`           | An unknown `value` to check |
+| Name: `type`               | Description                                                                      |
+| :------------------------- | :------------------------------------------------------------------------------- |
+| value: `Type`              | A generic `Type` `value`, by default of type detected from the `value`, to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                        |
-| :-------- | :-------: | :--------------------------------- |
-| `boolean` | `boolean` | The **return type** is a `boolean` |
+| Returns                            | Type      | Description                        |
+| :--------------------------------- | :-------: | :--------------------------------- |
+| `value is Never<AnyBoolean, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `boolean` or [`Boolean`][boolean] changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<AnyBoolean, Type>`][type-never] |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean`.
+The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` or [`Boolean`][boolean] instance.
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { isNotBoolean } from '@angular-package/type';
+
+const anyBoolean: any = true;
+const strictBoolean = false;
+const objectBoolean = new Boolean(strictBoolean);
+
+isNotBoolean(anyBoolean); // false; return type is `value is any`
+isNotBoolean(strictBoolean); // false; return type is `value is never`
+isNotBoolean(objectBoolean); // false; return type is `value is never`
+
+```
 
 ----
 
 ### isNotDefined
 
-Use `isNotDefined()` or `is.not.defined()` to check if an **unknown** `value` is an `undefined` type and is equal to `undefined`.
+![fix][update]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `defined` by changing the `value` type to a generic `Type` and the return type to `value is Undefined<Type>`.
+
+Use `isNotDefined()` or `is.not.defined()` to check if a generic `Type` `value` is an `undefined` type and is equal to `undefined`.
 
 ```typescript
-const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);
+const isNotDefined: IsNotDefined =
+  <Type>(value: Type, callback: ResultCallback = resultCallback): value is Undefined<Type> =>
+    callback(
+      typeOf(value) === 'undefined' &&
+      typeof value === 'undefined' &&
+      value === undefined,
+      value
+    );
 ```
+
+**Generic type variables:**
+
+| Name   | Default value    | Description |
+| :----- | :--------------- | :---------- |
+| `Type` | From the `value` | A generic `Type` variable from the `value` to the return type `value is Undefined<Type>` |
 
 **Parameters:**
 
 | Name: `type`               | Description                 |
 | :------------------------- | :-------------------------- |
-| value: `unknown`           | An unknown `value` to check |
+| value: `Type`              | A generic `Type` `value`, by default of type detected from the `value`, to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                        |
-| :-------- | :-------: | :--------------------------------- |
-| `boolean` | `boolean` | The **return type** is a `boolean` |
+| Returns                    | Type      | Description                         |
+| :------------------------- | :-------: | :---------------------------------- |
+| `value is Undefined<Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type other than `undefined` changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Undefined<Type>`][type-undefined] |
 
 The **return value** is a `boolean` indicating whether or not the `value` is not defined, is `undefined`.
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { isNotDefined } from '@angular-package/type';
+
+const anyUndefined: any = undefined;
+const firstName = undefined;
+const surname = 'My last name ';
+
+isNotDefined(anyUndefined); // true; return type is `value is any`
+isNotDefined(firstName); // true;  return type is `value is undefined`
+isNotDefined(surname); // false; return type is `value is never`
+
+```
 
 ----
 
 ### isNotFunction
 
-Use `isNotFunction()` or `is.not.function()` to check if an **unknown** `value` is **not** a `function` type and **not** an instance of `Function`.
+![fix][update]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `function` by changing the `value` type to a generic `Type` and the return type to `value is Never<Func, Type>`.
+
+Use `isNotFunction()` or `is.not.function()` to check if a generic `Type` `value` is **not** a `function` type and **not** an instance of [`Function`](#func).
 
 ```typescript
-const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false, value);
+const isNotFunction: IsNotFunction = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<Func, Type> =>
+  callback(
+    typeOf(value) !== 'function' &&
+    typeof value !== 'function' &&
+    value instanceof Function === false,
+    value
+  );
 ```
+
+**Generic type variables:**
+
+| Name   | Default value    | Description |
+| :----- | :--------------- | :---------- |
+| `Type` | From the `value` | A generic `Type` variable from the `value` to the return type `value is Never<Func, Type>` |
 
 **Parameters:**
 
-| Name: `type`               | Description                 |
-| :------------------------- | :-------------------------- |
-| value: `unknown`           | An unknown `value` to check |
+| Name: `type`               | Description                                                                      |
+| :------------------------- | :------------------------------------------------------------------------------- |
+| value: `Type`              | A generic `Type` `value`, by default of type detected from the `value`, to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                        |
-| :-------- | :-------: | :--------------------------------- |
-| `boolean` | `boolean` | The **return type** is a `boolean` |
+| Returns                      | Type      | Description                         |
+| :--------------------------- | :-------: | :---------------------------------- |
+| `value is Never<Func, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `Func` changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<Func, Type>`][type-never] |
 
 The **return value** is a `boolean` indicating whether or not the `value` is not a `function`.
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { IsNotFunction } from '@angular-package/type';
+
+const anyFunc: any = (x: number) => x + 5;
+const myFunc: Func = (x: string) => x;
+
+isNotFunction(anyFunc); // false; return type is `value is any`
+isNotFunction(myFunc); // false; return type is `value is never`
+isNotFunction('maybe i am not'); // true; return type is `value is string`
+
+```
 
 ----
 
 ### isNotNull
 
-Use `isNotNull()` or `is.not.null()` to check if an **unknown** `value` is **not** a `null` type and **not** equal to `null`.
+![fix][update]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `null` by changing `value` type to a generic `Type` and the return type to `value is Never<null, Type>`.
+
+Use `isNotNull()` or `is.not.null()` to check if a generic `Type` `value` is **not** a `null` type and **not** equal to `null`.
 
 ```typescript
-const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
+const isNotNull: IsNotNull = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<null, Type> =>
   callback(typeOf(value) !== 'null' && value !== null, value);
 ```
+
+**Generic type variables:**
+
+| Name   | Default value    | Description |
+| :----- | :--------------- | :---------- |
+| `Type` | From the `value` | A generic `Type` variable from the `value` to the return type `value is Never<null, Type>` |
 
 **Parameters:**
 
 | Name: `type`               | Description                 |
 | :------------------------- | :-------------------------- |
-| value: `unknown`           | An unknown `value` to check |
+| value: `Type`              | A generic `Type` `value`, by default of type detected from the `value` to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                                                       |
-| :-------- | :-------: | :---------------------------------------------------------------- |
-| `boolean` | `boolean` | The **return type** is a `boolean` |
+| Returns                      | Type      | Description                         |
+| :--------------------------- | :-------: | :---------------------------------- |
+| `value is Never<null, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `null` changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<null, Type>`][type-never] |
 
 The **return value** is a `boolean` indicating whether or not the `value` is not `null`.
+
+**Usage:**
+
+```typescript
+// Example usage
+import { isNotNull } from '@angular-package/type';
+
+const anyNull: any = null;
+const firstName = null;
+
+isNotNull(anyNull); // return type is `value is any`
+isNotNull(firstName); // return type is `value is never`
+
+```
 
 ----
 
 ### isNotNumber
 
-Use `isNotNumber()` or `is.not.number()` to check if an **unknown** `value` is **not** a `number` type and **not** an instance of `Number`.
+![fix][update]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not a `number` or `Number` by changing `value` type to a generic `Type` and the return type to `value is Never<number, Type>`.
+
+Use `isNotNumber()` or `is.not.number()` to check if a generic `Type` `value` is **not** a `number` type and **not** an instance of [`Number`][number].
 
 ```typescript
-const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultCallback): boolean =>
+const isNotNumber: IsNotNumber = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<AnyNumber, Type> =>
   callback(
     typeOf(value) !== 'number' &&
     typeof value !== 'number' &&
@@ -1934,77 +2060,149 @@ const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultC
   );
 ```
 
+**Generic type variables:**
+
+| Name   | Default value    | Description |
+| :----- | :--------------- | :---------- |
+| `Type` | From the `value` | A generic `Type` variable from the `value` to the return type `value is Never<AnyNumber, Type>` |
+
 **Parameters:**
 
-| Name: `type`               | Description                 |
-| :------------------------- | :-------------------------- |
-| value: `unknown`           | An unknown `value` to check |
+| Name: `type`               | Description                                                             |
+| :------------------------- | :---------------------------------------------------------------------- |
+| value: `Type`              | A generic `Type`, by default of type detected from the `value` to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                                                       |
-| :-------- | :-------: | :---------------------------------------------------------------- |
-| `boolean` | `boolean` | The **return type** is a `boolean` as the result of its statement |
+| Returns                           | Type      | Description                         |
+| :-------------------------------- | :-------: | :---------------------------------- |
+| `value is Never<AnyNumber, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `number` or [`Number`][number] changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<AnyNumber, Type>`][type-never] |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `number`.
+The **return value** is a `boolean` indicating whether or not the `value` is not a `number` or [`Number`][number] instance.
+
+**Usage:**
+
+```typescript
+// Example usage
+import { isNotNumber } from '@angular-package/type';
+
+const anyNumber: any = 'any number';
+const firstName = 'firstName';
+const age = 27;
+const objectNumber = new Number(927);
+
+isNotNumber(anyNumber); // return type is `value is any`
+isNotNumber(firstName); // return type is `value is string`
+isNotNumber(age); // return type is `value is never`
+isNotNumber(objectNumber); // return type is `value is never`
+
+```
 
 ----
 
 ### isNotString
 
-Use `isNotString()` or `is.not.string()` to check if an **unknown** `value` is **not** a `string` type and **not** an instance of `String`.
+![fix][update]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not a `string` or [`String`][string] by changing `value` type to a generic `Type` and the return type to `value is Never<string, Type>`.
+
+Use `isNotString()` or `is.not.string()` to check if a generic `Type` `value` is **not** a `string` type and **not** an instance of [`String`][string].
 
 ```typescript
-const isNotString: IsNotString = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false, value);
+const isNotString: IsNotString = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<AnyString, Type> =>
+  callback(
+    typeOf(value) !== 'string' &&
+    typeof value !== 'string' &&
+    value instanceof String === false,
+    value
+  );
 ```
+
+**Generic type variables:**
+
+| Name   | Default value    | Description |
+| :----- | :--------------- | :---------- |
+| `Type` | From the `value` | A generic `Type` variable from the `value` to the return type `value is Never<AnyString, Type>` |
 
 **Parameters:**
 
-| Name: `type`               | Description                 |
-| :------------------------- | :-------------------------- |
-| value: `unknown`           | An unknown `value` to check |
+| Name: `type`               | Description                                                             |
+| :------------------------- | :---------------------------------------------------------------------- |
+| value: `Type`              | A generic `Type`, by default of type detected from the `value` to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                         |
-| :-------- | :-------: | :---------------------------------- |
-| `boolean` | `boolean` | The **return type** is a `boolean`  |
+| Returns                           | Type      | Description                         |
+| :-------------------------------- | :-------: | :---------------------------------- |
+| `value is Never<AnyString, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `string` or [`String`][string] changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<AnyString, Type>`][type-never] |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `string`.
+The **return value** is a `boolean` indicating whether or not the `value` is not a `string` or [`String`][string] instance.
+
+**Usage:**
+
+```typescript
+// Example usage
+import { isNotString } from '@angular-package/type';
+
+const anyString: any = 'any string';
+const firstName = 'firstName';
+const age = 27;
+const objectString = new String('hold me');
+
+isNotString(anyString); // return type is `value is any`
+isNotString(firstName); // return type is `value is never`
+isNotString(age); // return type is `value is number`
+isNotString(objectString); // return type is `value is never`
+
+```
 
 ----
 
 ### isNotUndefined
 
-Use `isNotUndefined()` or `is.not.undefined()` to check if an **unknown** `value` is **not** an `undefined` type and **not** equal to `undefined`.
+![fix][update]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is not `undefined` by changing `value` type to a generic `Type` and the return type to `value is Defined<Type>`.
+
+Use `isNotUndefined()` or `is.not.undefined()` to check if a generic `Type` `value` is **not** an `undefined` type and **not** equal to `undefined`.
 
 ```typescript
-const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
+const isNotUndefined: IsNotUndefined = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Defined<Type> =>
+  callback(
+    typeOf(value) !== 'undefined' &&
+    typeof value !== 'undefined' &&
+    value !== undefined,
+    value
+  );
 ```
 
 **Parameters:**
 
-| Name: `type`               | Description                 |
-| :------------------------- | :-------------------------- |
-| value: `unknown`           | An unknown `value` to check |
+| Name: `type`               | Description                                                                      |
+| :------------------------- | :------------------------------------------------------------------------------- |
+| value: `Type`              | A generic `Type` `value`, by default of type detected from the `value`, to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
-| Returns   | Type      | Description                        |
-| :-------- | :-------: | :--------------------------------- |
-| `boolean` | `boolean` | The **return type** is a `boolean` |
+| Returns                  | Type      | Description                        |
+| :----------------------- | :-------: | :--------------------------------- |
+| `value is Defined<Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `undefined` changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Defined<Type>`][type-defined] |
 
 The **return value** is a `boolean` indicating whether or not the `value` is not `undefined`.
 
 **Usage:**
 
 ```typescript
-// Example usage with the problem
+// Example usage.
 import { is } from '@angular-package/type';
 
 interface Config {
@@ -2258,7 +2456,7 @@ guardClass<Class>(FUNCTION); // type error
 
 ![update][update]
 
-`4.1.0`: Fixes the `value` is not guarded by changing its type to  [`Defined<Type>`][defined].
+`4.1.0`: Fixes the `value` is not guarded by changing its type to  [`Defined<Type>`][type-defined].
 
 Use `guardDefined()` or `guard.is.defined()` to guard the `value` to be defined.
 
@@ -2271,20 +2469,20 @@ const guardDefined: GuardDefined = <Type>(value: Defined<Type>, callback?: Resul
 
 | Name   | Default value    | Description                                                                                         |
 | :----- | :--------------- | :-------------------------------------------------------------------------------------------------- |
-| `Type` | From the `value` | Guarded with [`Defined<Type>`][defined], a generic `Type` variable from the `value` to the return type `value is Defined<Type>` |
+| `Type` | From the `value` | Guarded with [`Defined<Type>`][type-defined], a generic `Type` variable from the `value` to the return type `value is Defined<Type>` |
 
 **Parameters:**
 
-| Name: `type`                | Description                                                                                                                  |
-| :-------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| value: `Defined<Type>`      | A generic type `value`, by default of [`Defined<Type>`][defined] type detected from the `value` to guard against `undefined` |
-| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error]                                    |
+| Name: `type`                | Description                                                                                                                       |
+| :-------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| value: `Defined<Type>`      | A generic type `value`, by default of [`Defined<Type>`][type-defined] type detected from the `value` to guard against `undefined` |
+| callback?: `ResultCallback` | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
 | Returns                  | Type      | Description                                                       |
 | :----------------------- | :-------: | :---------------------------------------------------------------- |
-| `value is Defined<Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `undefined` changes to `never` and the **return type** is a `boolean` as the result of its statement indicating the `value` is [`Defined<Type>`][defined] |
+| `value is Defined<Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `undefined` changes to `never` and the **return type** is a `boolean` as the result of its statement indicating the `value` is [`Defined<Type>`][type-defined] |
 
 The **return value** is a `boolean` indicating whether or not the `value` is defined.
 
@@ -2825,17 +3023,23 @@ The **return value** is a `boolean` indicating whether or not the `value` is `un
 
 ### AnyBoolean
 
+Represents `boolean` type or `Boolean` object.
+
 ```typescript
 type AnyBoolean = Exclude<boolean | Boolean, true | false>;
 ```
 
 ### AnyNumber
 
+Represents `number` type or `Number` object.
+
 ```typescript
 type AnyNumber = number | Number;
 ```
 
 ### AnyString
+
+Represents `string` type or `String` object.
 
 ```typescript
 type AnyString = string | String;
@@ -2850,7 +3054,7 @@ type Constructor<Type> = new (...args: any[]) => Type;
 ### Defined
 
 ```typescript
-type Defined<T> = T extends undefined ? never : T;
+type Defined<Type> = Never<undefined, Type>;
 ```
 
 ### CycleHook
@@ -2874,6 +3078,14 @@ Name of the `object` property.
 
 ```typescript
 type Key =  number | string | symbol;
+```
+
+### Never
+
+Choose a type to exclude. A generic `Type` is never a `Not` type.
+
+```typescript
+type Never<Not, Type> = Type extends Not ? never : Type;
 ```
 
 ### Primitive
@@ -2912,6 +3124,14 @@ Main types as `string`.
 
 ```typescript
 type Types<Obj> = Constructor<Obj> | 'function' | 'object' | Primitives;
+```
+
+### Undefined
+
+Undefined or `never` - treat types as `never` excluding `undefined`.
+
+```typescript
+export type Undefined<Type> = Type extends undefined ? Type : never;
 ```
 
 ----
@@ -3229,10 +3449,12 @@ MIT © angular-package ([license][license])
 <!-- Types -->
 [callback]: #callback
 [constructor]: #constructor
-[defined]: #defined
+[type-defined]: #defined
+[type-never]: #never
 [resultcallback]: #resultcallback
 [key]: #key
 [type]: #type
+[type-undefined]: #undefined
 
 <!-- Javascript  -->
 [array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
@@ -3266,7 +3488,7 @@ MIT © angular-package ([license][license])
 [symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 [symbolconstructor]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
 
-[undefined]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined
+[js-undefined]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined
 
 <!-- Typescript -->
 [ts-classes]: https://www.typescriptlang.org/docs/handbook/2/classes.html

--- a/README.md
+++ b/README.md
@@ -1572,9 +1572,9 @@ const isPrimitive: IsPrimitive = <T extends Primitive>(
 
 **Generic type variables:**
 
-| Name                    | Default value             | Description |
-| :---------------------- | :------------------------ | :---------- |
-| `T` extends `Primitive` | [`Primitive`](#primitive) | Guarded with [`Primitive`](#primitive) type, `T` variable to the return type `value is T` |
+| Name                  | Default value             | Description |
+| :-------------------- | :------------------------ | :---------- |
+| `T extends Primitive` | [`Primitive`](#primitive) | Guarded with [`Primitive`](#primitive) type, `T` variable to the return type `value is T` |
 
 **Parameters:**
 
@@ -1737,9 +1737,9 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 
 **Generic type variables:**
 
-| Name                       | Default value   | Description |
-| :------------------------- | :-------------- | :---------- |
-| `T` extends [`Type`][type] | [`Type`][type]  | Guarded with [`Type`][type] type, `T` variable to the return type `value is T` |
+| Name             | Default value   | Description |
+| :--------------- | :-------------- | :---------- |
+| `T extends Type` | [`Type`][type]  | Guarded with [`Type`][type] type, `T` variable to the return type `value is T` |
 
 **Parameters:**
 
@@ -2505,9 +2505,9 @@ const guardObject: GuardObject = <Obj extends object>(value: Obj, callback?: Res
 
 **Generic type variables:**
 
-| Name  | Default value    | Description                                                                              |
-| :---- | :--------------- | :--------------------------------------------------------------------------------------- |
-| `Obj` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
+| Name                 | Default value    | Description                                                                              |
+| :------------------- | :--------------- | :--------------------------------------------------------------------------------------- |
+| `Obj extends object` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
 
 **Parameters:**
 
@@ -2546,9 +2546,9 @@ const guardObjectKey: GuardObjectKey =
 
 **Generic type variables:**
 
-| Name  | Default value    | Description                                                                              |
-| :---- | :--------------- | :--------------------------------------------------------------------------------------- |
-| `Obj` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
+| Name                 | Default value    | Description                                                                              |
+| :------------------- | :--------------- | :--------------------------------------------------------------------------------------- |
+| `Obj extends object` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
 
 **Parameters:**
 
@@ -2591,9 +2591,9 @@ const guardObjectKeys: GuardObjectKeys =
 
 **Generic type variables:**
 
-| Name  | Default value    | Description                                                                              |
-| :---- | :--------------- | :--------------------------------------------------------------------------------------- |
-| `Obj` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
+| Name                 | Default value    | Description                                                                              |
+| :------------------- | :--------------- | :--------------------------------------------------------------------------------------- |
+| `Obj extends object` | From the `value` | Guarded with `object`, `Obj` variable from the `value` to the return type `value is Obj` |
 
 **Parameters:**
 
@@ -2670,9 +2670,9 @@ const guardPrimitive: GuardPrimitive =
 
 **Generic type variables:**
 
-| Name                                     | Default value    | Description |
-| :--------------------------------------- | :--------------- | :---------- |
-| `Type` extends [`Primitive`](#primitive) | From the `value` | Guarded with [`Primitive`](#primitive) type, `Type` variable from the `value` to the return type `value is Type` |
+| Name                     | Default value    | Description |
+| :----------------------- | :--------------- | :---------- |
+| `Type extends Primitive` | From the `value` | Guarded with [`Primitive`](#primitive) type, `Type` variable from the `value` to the return type `value is Type` |
 
 **Parameters:**
 
@@ -2707,9 +2707,9 @@ const guardString: GuardString = <S extends AnyString>(value: S, callback?: Resu
 
 **Generic type variables:**
 
-| Name                                  | Default value    | Description |
-| :------------------------------------ | :--------------- | :---------- |
-| `S` extends [`AnyString`](#anystring) | From the `value` | Guarded with [`AnyString`](#anystring) type, `S` variable from the `value` to the return type `value is S` |
+| Name                  | Default value    | Description |
+| :-------------------- | :--------------- | :---------- |
+| `S extends AnyString` | From the `value` | Guarded with [`AnyString`](#anystring) type, `S` variable from the `value` to the return type `value is S` |
 
 **Parameters:**
 
@@ -2769,9 +2769,9 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
 
 **Generic type variables:**
 
-| Name                       | Default value    | Description |
-| :------------------------- | :--------------- | :---------- |
-| `T` extends [`Type`][type] | From the `value` | Guarded with [`Type`][type] type,`T` variable from the `value` to the return type `value is T` |
+| Name             | Default value    | Description |
+| :--------------- | :--------------- | :---------- |
+| `T extends Type` | From the `value` | Guarded with [`Type`][type] type,`T` variable from the `value` to the return type `value is T` |
 
 **Parameters:**
 

--- a/README.md
+++ b/README.md
@@ -639,28 +639,36 @@ isClass(() => 5); // false
 Use `isDefined()` or `is.defined()` to check if a generic `Type` `value` is **not** an `undefined` type and is **not** equal to `undefined`.
 
 ```typescript
-const isDefined: IsDefined = <Type>(value: Type, callback: ResultCallback = resultCallback): value is Defined<Type> =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
+const isDefined: IsDefined = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Defined<Type> =>
+  callback(
+    typeOf(value) !== 'undefined' &&
+    typeof value !== 'undefined' &&
+    value !== undefined,
+    value
+  );
 ```
 
 **Generic type variables:**
 
-| Name   | Default value    | Description                                                    |
-| :----- | :--------------- | :------------------------------------------------------------- |
-| `Type` | From the `value` | A generic variable to the return type `value is Defined<Type>` |
+| Name   | Default value    | Description                                                           |
+| :----- | :--------------- | :-------------------------------------------------------------------- |
+| `Type` | From the `value` | A generic `Type` variable to the return type `value is Defined<Type>` |
 
 **Parameters:**
 
-| Name: `type`               | Description                     |
-| :------------------------- | :------------------------------ |
-| value: `unknown`           | A generic type `value` to check |
+| Name: `type`               | Description                                                                      |
+| :------------------------- | :------------------------------------------------------------------------------- |
+| value: `Type`              | A generic `Type` `value`, by default of type detected from the `value`, to check |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
 | Returns                  | Type      | Description                         |
-| :----------------------- | :-------: | :---------------------------------  |
-| `value is Defined<Type>` | `boolean` | The **return type** is a `boolean`  |
+| :----------------------- | :-------: | :---------------------------------- |
+| `value is Defined<Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `undefined` changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Defined<Type>`][type-defined] |
 
 The **return value** is a `boolean` indicating whether or not the `value` is defined, not `undefined`
 
@@ -2220,13 +2228,7 @@ function configFunction(value: string): string {
   return '';
 }
 
-// Cause typescript returns `boolean` this will generate a type error
 if (is.not.undefined(config.a)) {
-  configFunction(config.a);
-}
-
-// Cause typescript return `value is undefined` will not generate an error
-if (!is.undefined(config.a)) {
   configFunction(config.a);
 }
 
@@ -3130,10 +3132,10 @@ type Types<Obj> = Constructor<Obj> | 'function' | 'object' | Primitives;
 
 ### Undefined
 
-Undefined or `never` - treat types as `never` excluding `undefined`.
+Undefined or never - treat types as `never` excluding `undefined`.
 
 ```typescript
-export type Undefined<Type> = Type extends undefined ? Type : never;
+type Undefined<Type> = Type extends undefined ? Type : never;
 ```
 
 ----

--- a/README.md
+++ b/README.md
@@ -2137,7 +2137,7 @@ const isNotString: IsNotString = <Type>(
 
 **Returns:**
 
-`value is Never<AnyString, Type>`
+The function returns statement `value is Never<AnyString, Type>`.
 
 | Type      | Description                         |
 | :-------: | :---------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1849,7 +1849,7 @@ const isNotBoolean: IsNotBoolean = <Type>(
 | :--------------------------------- | :-------: | :--------------------------------- |
 | `value is Never<AnyBoolean, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `boolean` or [`Boolean`][boolean] changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<AnyBoolean, Type>`][type-never] |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` or [`Boolean`][boolean] instance.
+The **return value** is a `boolean` indicating whether or not the `value` is not a `boolean` and [`Boolean`][boolean] instance.
 
 **Usage:**
 
@@ -2079,7 +2079,7 @@ const isNotNumber: IsNotNumber = <Type>(
 | :-------------------------------- | :-------: | :---------------------------------- |
 | `value is Never<AnyNumber, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `number` or [`Number`][number] changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<AnyNumber, Type>`][type-never] |
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `number` or [`Number`][number] instance.
+The **return value** is a `boolean` indicating whether or not the `value` is not a `number` and [`Number`][number] instance.
 
 **Usage:**
 
@@ -2137,11 +2137,13 @@ const isNotString: IsNotString = <Type>(
 
 **Returns:**
 
-| Returns                           | Type      | Description                         |
-| :-------------------------------- | :-------: | :---------------------------------- |
-| `value is Never<AnyString, Type>` | `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `string` or [`String`][string] changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<AnyString, Type>`][type-never] |
+`value is Never<AnyString, Type>`
 
-The **return value** is a `boolean` indicating whether or not the `value` is not a `string` or [`String`][string] instance.
+| Type      | Description                         |
+| :-------: | :---------------------------------- |
+| `boolean` | By default `Type` variable is equal to the type detected from the `value`, but the detected type `string` or [`String`][string] changes to `never` and the **return type** is a `boolean` as the result of its statement `value` is [`Never<AnyString, Type>`][type-never] |
+
+The **return value** is a `boolean` indicating whether or not the `value` is not a `string` and [`String`][string] instance.
 
 **Usage:**
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,10 @@ isClass(() => 5); // false
 
 ### isDefined
 
+![fix][fix]
+
+`4.1.2`: Fixes the return type `boolean`, which doesn't strictly indicate the `value` is defined by changing the `value` type to a generic `Type` and the return type to `value is Defined<Type>`.
+
 Use `isDefined()` or `is.defined()` to check if a generic `Type` `value` is **not** an `undefined` type and is **not** equal to `undefined`.
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -1204,7 +1204,7 @@ const isObjectKey: IsObjectKey =
 | Name: `type`               | Description                                           |
 | :------------------------- | :---------------------------------------------------- |
 | value: `any`               | Any `value` to check if it contains a specified `key` |
-| key: `Key | Key[]`         | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| key: `Key \| Key[]`        | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
@@ -1357,7 +1357,7 @@ const isObjectKeyIn: IsObjectKeyIn =
 | Name: `type`               | Description                                                                  |
 | :------------------------- | :--------------------------------------------------------------------------- |
 | value: `any`               | Any `value` to check if it contains a specified `key`                        |
-| key: `Key | Key[]`         | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| key: `Key \| Key[]`        | A [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
@@ -1483,10 +1483,10 @@ const isObjectKeys: IsObjectKeys = <Type = object>(
 
 **Parameters:**
 
-| Name: `type`                    | Description                                                                                 |
-| :------------------------------ | :------------------------------------------------------------------------------------------ |
-| value: `any`                    | Any `value` to check if it contains **some** of the specified `keys`                        |
-| ...keys: `(Key | Array<Key>)[]` | A [rest parameter][function-rest-parameter] single [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
+| Name: `type`                     | Description                                                                                 |
+| :------------------------------- | :------------------------------------------------------------------------------------------ |
+| value: `any`                     | Any `value` to check if it contains **some** of the specified `keys`                        |
+| ...keys: `(Key \| Array<Key>)[]` | A [rest parameter][function-rest-parameter] single [`Key`][key] type or an array of [`Key`][key] type to check in the `value` |
 
 **Returns:**
 
@@ -2552,11 +2552,11 @@ const guardObjectKey: GuardObjectKey =
 
 **Parameters:**
 
-| Name: `type`                     | Description                                                                                                              |
-| :------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| value: `Obj`                     | An `object` of a generic `Obj` type that contains the `key`, by default of type detected from the `value` to guard       |
-| key: `keyof Obj | (keyof Obj)[]` | A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains                   |
-| callback?: `ResultCallback`      | An optional [`ResultCallback`][resultcallback] type to handle the result before returns eg. to throw an [`Error`][error] |
+| Name: `type`                      | Description                                                                                                              |
+| :-------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| value: `Obj`                      | An `object` of a generic `Obj` type that contains the `key`, by default of type detected from the `value` to guard       |
+| key: `keyof Obj \| (keyof Obj)[]` | A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains                   |
+| callback?: `ResultCallback`       | An optional [`ResultCallback`][resultcallback] type to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**
 
@@ -2597,10 +2597,10 @@ const guardObjectKeys: GuardObjectKeys =
 
 **Parameters:**
 
-| Name: `type`                         | Description                                                                                                       |
-| :----------------------------------- | :---------------------------------------------------------------------------------------------------------------- |
-| value: `Obj`                         | An object of a generic `Obj` type that contains the `keys`, by default of type detected from the `value` to guard |
-| ...keys: `keyof Obj | (keyof Obj)[]` | A [rest parameter][function-rest-parameter] single key of `Obj` or an array of key of `Obj` type as the name of the property that the `value` contains |
+| Name: `type`                          | Description                                                                                                       |
+| :------------------------------------ | :---------------------------------------------------------------------------------------------------------------- |
+| value: `Obj`                          | An object of a generic `Obj` type that contains the `keys`, by default of type detected from the `value` to guard |
+| ...keys: `keyof Obj \| (keyof Obj)[]` | A [rest parameter][function-rest-parameter] single key of `Obj` or an array of key of `Obj` type as the name of the property that the `value` contains |
 
 **Returns:**
 
@@ -2771,7 +2771,7 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
 
 | Name             | Default value    | Description |
 | :--------------- | :--------------- | :---------- |
-| `T extends Type` | From the `value` | Guarded with [`Type`][type],`T` variable from the `value` to the return type `value is T` |
+| `T extends Type` | From the `value` | Guarded with [`Type`][type], `T` variable from the `value` to the return type `value is T` |
 
 **Parameters:**
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ const isArray: IsArray = <Type = any>(value: any, callback: ResultCallback = res
 
 | Returns                | Type      | Description                                                       |
 | :--------------------- | :-------: | :---------------------------------------------------------------- |
-| `value is Array<Type>` | `boolean` | By default `Type` variable is equal  to `any` and the **return type** is a `boolean` as the result of its statement indicating the `value` is an [`Array`][array] of `any` type |
+| `value is Array<Type>` | `boolean` | By default `Type` variable is equal to `any` and the **return type** is a `boolean` as the result of its statement indicating the `value` is an [`Array`][array] of `any` type |
 
 The **return value** is a `boolean` indicating whether or not the `value` is an [`Array`][array].
 
@@ -1588,7 +1588,7 @@ const isPrimitive: IsPrimitive = <T extends Primitive>(
 
 | Returns      | Type      | Description                                                            |
 | :----------- | :-------: | :--------------------------------------------------------------------- |
-| `value is T` | `boolean` | By default `T` variable is equal  to [`Primitive`](#primitive) and the **return type** is a `boolean` as the result of its statement indicating the `value` is [`Primitive`](#primitive) |
+| `value is T` | `boolean` | By default `T` variable is equal to [`Primitive`](#primitive) and the **return type** is a `boolean` as the result of its statement indicating the `value` is [`Primitive`](#primitive) |
 
 The **return value** is a `boolean` indicating whether or not the `value` is a `type` from the [`Primitives`](#primitives).
 
@@ -1739,13 +1739,13 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 
 | Name             | Default value   | Description |
 | :--------------- | :-------------- | :---------- |
-| `T extends Type` | [`Type`][type]  | Guarded with [`Type`][type] type, `T` variable to the return type `value is T` |
+| `T extends Type` | [`Type`][type]  | Guarded with [`Type`][type], `T` variable to the return type `value is T` |
 
 **Parameters:**
 
-| Name: `type`               | Description                                         |
-| :------------------------- | :-------------------------------------------------- |
-| value: `any`               | Any `value` to check if its type is from the `type` |
+| Name: `type`               | Description                                                                                 |
+| :------------------------- | :------------------------------------------------------------------------------------------ |
+| value: `any`               | Any `value` to check if its type is from the `type`                                         |
 | type: `Types<T>`           | A `string` or generic `Constructor<T>` type from the [`Types`](#types) to check the `value` |
 | callback: `ResultCallback` | A [`ResultCallback`][resultcallback] type function, which by default is [`resultCallback()`][callback] to handle the result before returns eg. to throw an [`Error`][error] |
 
@@ -1753,7 +1753,7 @@ const isType: IsType = <T extends Type>(value: any, type: Types<T>, callback: Re
 
 | Returns      | Type      | Description                                                                                                           |
 | :----------- | :-------: | :-------------------------------------------------------------------------------------------------------------------- |
-| `value is T` | `boolean` | By default `T` variable is equal  to [`Type`][type] and the **return type** is a `boolean` as the result of its statement indicating the `value` is [`Type`][type] |
+| `value is T` | `boolean` | By default `T` variable is equal to [`Type`][type] and the **return type** is a `boolean` as the result of its statement indicating the `value` is [`Type`][type] |
 
 The **return value** is a `boolean` indicating whether or not the `value` is the [`Type`][type] from a `type` of the [`Types`](#types).
 
@@ -2771,7 +2771,7 @@ const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback
 
 | Name             | Default value    | Description |
 | :--------------- | :--------------- | :---------- |
-| `T extends Type` | From the `value` | Guarded with [`Type`][type] type,`T` variable from the `value` to the return type `value is T` |
+| `T extends Type` | From the `value` | Guarded with [`Type`][type],`T` variable from the `value` to the return type `value is T` |
 
 **Parameters:**
 

--- a/README.md
+++ b/README.md
@@ -2347,7 +2347,7 @@ const guardInstance: GuardInstance =
 | Name: `type`                    | Description                                                                                                                       |
 | :------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
 | value: `Obj`                    | An `object`, by default of a generic `Obj` type detected from the `value` to guard and to check if it's a `constructor` instance  |
-| constructor: `Constructor<Obj>` | A [`class`][ts-classes] or [`[function]`][ts-function] that specifies the type of the [`constructor`][constructor]                |
+| constructor: `Constructor<Obj>` | A [`class`][ts-classes] or [`function`][ts-function] that specifies the type of the [`constructor`][constructor]                |
 | callback?: `ResultCallback`     | An optional [`ResultCallback`][resultcallback] type function to handle the result before returns eg. to throw an [`Error`][error] |
 
 **Returns:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@angular-package/type",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@angular-package/type",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-package/type",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Common types, type guards and type checkers.",
   "author": "Angular Package <angular-package@wvvw.dev> (https://wvvw.dev)",
   "homepage": "https://github.com/angular-package/type#readme",

--- a/src/guard/lib/guard-array.func.ts
+++ b/src/guard/lib/guard-array.func.ts
@@ -5,8 +5,8 @@ import { GuardArray } from '../type/guard-array.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be an `Array` of a generic `Type`.
- * @param value A generic `Type` `Array` `value` to guard.
- * @param callback An optional `ResultCallback` function to handle result before returns.
+ * @param value An `Array` of a generic `Type`, by default type detected from the `value` - to guard.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is an `Array` of a generic `Type`.
  */
 export const guardArray: GuardArray = <Type>(value: Array<Type>, callback?: ResultCallback): value is Array<Type> =>

--- a/src/guard/lib/guard-big-int.func.ts
+++ b/src/guard/lib/guard-big-int.func.ts
@@ -6,7 +6,7 @@ import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be a `bigint`.
  * @param value A `bigint` type `value` to guard.
- * @param callback Optional `ResultCallback` function to handle result before returns.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a `bigint`.
  */
 export const guardBigInt: GuardBigInt = (value: bigint, callback?: ResultCallback): value is bigint =>

--- a/src/guard/lib/guard-boolean.func.ts
+++ b/src/guard/lib/guard-boolean.func.ts
@@ -6,8 +6,8 @@ import { GuardBoolean } from '../type/guard-boolean.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be any type of a boolean.
- * @param value An `AnyBoolean` type from the `value` to guard.
- * @param callback An optional `ResultCallback` function to handle result before returns.
+ * @param value An `AnyBoolean` type `value`, by default of type detected from the `value` - to guard.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a `boolean` type or `Boolean` object.
  */
 export const guardBoolean: GuardBoolean = <B extends AnyBoolean>(value: B, callback?: ResultCallback): value is B =>

--- a/src/guard/lib/guard-class.func.ts
+++ b/src/guard/lib/guard-class.func.ts
@@ -5,9 +5,10 @@ import { GuardClass } from '../type/guard-class.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be a generic `Class` type of `class`.
- * @param value A generic `Class` type from the `value` to guard.
- * @param callback An Optional `ResultCallback` function to handle result before returns.
+ * @param value A `Function` type `value`, by default of a generic `Class` type detected from the `value` to guard.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a generic `class`.
  */
+// tslint:disable-next-line: ban-types
 export const guardClass: GuardClass = <Class extends Function>(value: Class, callback?: ResultCallback): value is Class =>
   isClass<Class>(value, callback);

--- a/src/guard/lib/guard-defined.func.ts
+++ b/src/guard/lib/guard-defined.func.ts
@@ -6,8 +6,8 @@ import { GuardDefined } from '../type/guard-defined.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be defined, not `undefined`.
- * @param value A generic `Type` type from the `value` to guard.
- * @param callback An optional `ResultCallback` function to handle result before returns.
+ * @param value A generic type `value`, by default of `Defined<Type>` type detected from the `value` to guard against `undefined`.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is defined, if `undefined` then returns `never`.
  */
 export const guardDefined: GuardDefined = <Type>(value: Defined<Type>, callback?: ResultCallback): value is Defined<Type> =>

--- a/src/guard/lib/guard-function.func.ts
+++ b/src/guard/lib/guard-function.func.ts
@@ -7,7 +7,7 @@ import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be a `Func` type.
  * @param value A `Func` type `value` to guard.
- * @param callback Optional `ResultCallback` function to handle result before returns.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a `Func`.
  */
 export const guardFunction: GuardFunction = (value: Func, callback?: ResultCallback): value is Func =>

--- a/src/guard/lib/guard-instance.func.ts
+++ b/src/guard/lib/guard-instance.func.ts
@@ -6,7 +6,8 @@ import { GuardInstance } from '../type/guard-instance.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be an `object` of a generic `Obj` type and an instance of `Constructor` type.
- * @param value A generic `Obj` type `value` to be an instance of the `constructor`.
+ * @param value An `object`, by default of a generic `Obj` type detected from the `value`
+ * to guard and check if it's a `constructor` instance.
  * @param constructor A class or function that specifies the type of the `constructor`.
  * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is an `instance` of a generic `Obj`.

--- a/src/guard/lib/guard-key.func.ts
+++ b/src/guard/lib/guard-key.func.ts
@@ -7,7 +7,7 @@ import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be one of the `string`, `number`, or `symbol`.
  * @param value A `Key` type `value` to guard.
- * @param callback Optional `ResultCallback` function to handle result before returns.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a `Key`.
  */
 export const guardKey: GuardKey = (value: Key, callback?: ResultCallback): value is Key =>

--- a/src/guard/lib/guard-null.func.ts
+++ b/src/guard/lib/guard-null.func.ts
@@ -6,7 +6,7 @@ import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be a `null`.
  * @param value A `null` type `value` to guard.
- * @param callback Optional `ResultCallback` function to handle result before returns.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a `null`.
  */
 export const guardNull: GuardNull = (value: null, callback?: ResultCallback): value is null =>

--- a/src/guard/lib/guard-number.func.ts
+++ b/src/guard/lib/guard-number.func.ts
@@ -6,8 +6,8 @@ import { GuardNumber } from '../type/guard-number.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be any type of a number.
- * @param value An `AnyNumber` type `value` to guard.
- * @param callback An optional `ResultCallback` function to handle result before returns.
+ * @param value An `AnyNumber` type `value`, by default of a generic `N` type detected from the `value` to guard.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a `number` type or `Number` object.
  */
 export const guardNumber: GuardNumber = <N extends AnyNumber>(value: N, callback?: ResultCallback): value is N =>

--- a/src/guard/lib/guard-object-key.func.ts
+++ b/src/guard/lib/guard-object-key.func.ts
@@ -5,9 +5,9 @@ import { GuardObjectKey } from '../type/guard-object-key.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be an `object` of a generic `Obj` type that contains the `key`.
- * @param value A generic `Obj` type `value` that contains the `key` to guard.
+ * @param value An `object` of a generic `Obj` type that contains the `key`, by default of type detected from the `value` - to guard.
  * @param key A key of `Obj` or an array of keys of `Obj` type as the name of the property that the `value` contains.
- * @param callback An optional `ResultCallback` function to handle result before returns.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is an `object` of a generic `Obj` containing the `key`.
  */
 export const guardObjectKey: GuardObjectKey =

--- a/src/guard/lib/guard-object-keys.func.ts
+++ b/src/guard/lib/guard-object-keys.func.ts
@@ -4,7 +4,7 @@ import { isObjectKeys } from '../../is/lib/is-object-keys.func';
 import { GuardObjectKeys } from '../type/guard-object-keys.type';
 /**
  * Guard the value to be an `object` of a generic `Type` with some of its own specified `keys`.
- * @param value A generic `Obj` type `value` that contains the `keys` to guard.
+ * @param value An object of a generic `Obj` type that contains the `keys`, by default of type detected from the `value` to guard.
  * @param keys A rest parameter single key of `Obj` or an array of keys of `Obj`, as the name of the property that the `value` contains.
  * @returns A `boolean` indicating whether or not the `value` is an `object` with some of its own specified `keys`.
  */

--- a/src/guard/lib/guard-object.func.ts
+++ b/src/guard/lib/guard-object.func.ts
@@ -5,8 +5,8 @@ import { GuardObject } from '../type/guard-object.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be an `object` of a generic `Obj` type.
- * @param value A generic `Obj` type `value` to guard.
- * @param callback An optional `ResultCallback` function to handle result before returns.
+ * @param value An `object` of a generic `Obj` type, by default of type detected from the `value` to guard.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is an `object` of a generic `Obj`.
  */
 export const guardObject: GuardObject = <Obj extends object>(value: Obj, callback?: ResultCallback): value is Obj =>

--- a/src/guard/lib/guard-primitive.func.ts
+++ b/src/guard/lib/guard-primitive.func.ts
@@ -7,9 +7,9 @@ import { Primitives } from '../../type/primitives.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be the `Primitive` from a `type` of the `Primitives`.
- * @param value A `Primitive` type `value` to guard.
+ * @param value A `Primitive` type `value`, by default of a generic `Type` detected from the `value` to guard.
  * @param type A `string` type from the `Primitives` to check the `value`.
- * @param callback Optional `ResultCallback` function to handle result before returns.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is the `Primitive` from the `type`.
  */
 export const guardPrimitive: GuardPrimitive =

--- a/src/guard/lib/guard-string.func.ts
+++ b/src/guard/lib/guard-string.func.ts
@@ -6,8 +6,8 @@ import { GuardString } from '../type/guard-string.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be any type of a string.
- * @param value An `AnyString` type `value` to guard.
- * @param callback An Optional `ResultCallback` function to handle result before returns.
+ * @param value An `AnyString` type `value`, by default of a generic `S` type detected from the `value` to guard.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a `string` type or `String` object.
  */
 export const guardString: GuardString = <S extends AnyString>(value: S, callback?: ResultCallback): value is S =>

--- a/src/guard/lib/guard-type.func.ts
+++ b/src/guard/lib/guard-type.func.ts
@@ -7,9 +7,9 @@ import { Type } from '../../type/type.type';
 import { Types } from '../../type/types.type';
 /**
  * Guard the `value` to be the `Type` from a `type` of the `Types`.
- * @param value A `Type` `value` to guard with the `type`.
+ * @param value A `Type` `value`, by default of a generic `T` type detected from the `value` to guard with the `type`.
  * @param type A `string` or generic `Constructor` type from the `Types` to check the `value`.
- * @param callback Optional `ResultCallback` function to handle result before returns.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is a type from the `Types`.
  */
 export const guardType: GuardType = <T extends Type>(value: T, type: Types<T>, callback?: ResultCallback): value is T  =>

--- a/src/guard/lib/guard-undefined.func.ts
+++ b/src/guard/lib/guard-undefined.func.ts
@@ -5,8 +5,8 @@ import { GuardUndefined } from '../type/guard-undefined.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
  * Guard the `value` to be `undefined`.
- * @param value A `undefined` type `value` to guard.
- * @param callback Optional `ResultCallback` function to handle result before returns.
+ * @param value An `undefined` type `value` to guard.
+ * @param callback An optional `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is `undefined`.
  */
 export const guardUndefined: GuardUndefined = (value: undefined, callback?: ResultCallback): value is undefined =>

--- a/src/is/lib/is-defined.func.ts
+++ b/src/is/lib/is-defined.func.ts
@@ -2,13 +2,14 @@
 import { resultCallback } from '../../lib/result-callback.func';
 import { typeOf } from '../../lib/type-of.func';
 // Type.
+import { Defined } from '../../type/defined.type';
 import { IsDefined } from '../type/is-defined.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
- * Checks if an unknown `value` is NOT an `undefined` type and is NOT equal to `undefined`.
- * @param value An `unknown` `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
+ * Checks if a generic type `value` is not an `undefined` type and is not equal to `undefined`.
+ * @param value A generic type `value` to check.
+ * @param callback A `ResultCallback` function to handle result before returns.
  * @returns A `boolean` indicating whether or not the `value` is defined, not `undefined`.
  */
-export const isDefined: IsDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
+export const isDefined: IsDefined = <Type>(value: Type, callback: ResultCallback = resultCallback): value is Defined<Type> =>
   callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);

--- a/src/is/lib/is-defined.func.ts
+++ b/src/is/lib/is-defined.func.ts
@@ -6,10 +6,18 @@ import { Defined } from '../../type/defined.type';
 import { IsDefined } from '../type/is-defined.type';
 import { ResultCallback } from '../../type/result-callback.type';
 /**
- * Checks if a generic type `value` is not an `undefined` type and is not equal to `undefined`.
- * @param value A generic type `value` to check.
- * @param callback A `ResultCallback` function to handle result before returns.
+ * Checks if a generic `Type` `value` is not an `undefined` type and is not equal to `undefined`.
+ * @param value A generic `Type` `value`, by default of type detected from the `value`, to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is defined, not `undefined`.
  */
-export const isDefined: IsDefined = <Type>(value: Type, callback: ResultCallback = resultCallback): value is Defined<Type> =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
+export const isDefined: IsDefined = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Defined<Type> =>
+  callback(
+    typeOf(value) !== 'undefined' &&
+    typeof value !== 'undefined' &&
+    value !== undefined,
+    value
+  );

--- a/src/is/not/lib/is-not-boolean.func.ts
+++ b/src/is/not/lib/is-not-boolean.func.ts
@@ -2,20 +2,23 @@
 import { resultCallback } from '../../../lib/result-callback.func';
 import { typeOf } from '../../../lib/type-of.func';
 // Type.
+import { AnyBoolean } from '../../../type/any-boolean.type';
 import { IsNotBoolean } from '../type/is-not-boolean.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
 /**
- * Checks if an unknown `value` is NOT a `boolean` type, NOT equal to `true` or `false` and NOT instance of `Boolean`.
- * @param value An unknown `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
- * @returns A `boolean` indicating whether or not the `value` is not `boolean`.
+ * Checks if a generic `Type` `value` is not a `boolean` type, and not instance of `Boolean`.
+ * @param value A generic `Type` `value`, by default of type detected from the `value`, to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
+ * @returns A `boolean` indicating whether or not the `value` is not `boolean` or `Boolean` instance.
  */
-export const isNotBoolean: IsNotBoolean = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
+export const isNotBoolean: IsNotBoolean = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<AnyBoolean, Type> =>
   callback(
     typeOf(value) !== 'boolean' &&
     typeof value !== 'boolean' &&
-    value instanceof Boolean === false &&
-    value !== true &&
-    value !== false,
+    value instanceof Boolean === false,
     value
   );

--- a/src/is/not/lib/is-not-defined.func.ts
+++ b/src/is/not/lib/is-not-defined.func.ts
@@ -4,11 +4,20 @@ import { typeOf } from '../../../lib/type-of.func';
 // Type.
 import { IsNotDefined } from '../type/is-not-defined.type';
 import { ResultCallback } from '../../../type/result-callback.type';
+import { Undefined } from '../../../type/undefined.type';
 /**
- * Checks if an unknown `value` is an `undefined` type and is equal to `undefined`.
- * @param value An unknown `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
+ * Checks if a generic `Type` `value` is an `undefined` type and is equal to `undefined`.
+ * @param value A generic `Type` `value`, by default of type detected from the `value`, to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is not defined.
  */
-export const isNotDefined: IsNotDefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) === 'undefined' && typeof value === 'undefined' && value === undefined, value);
+export const isNotDefined: IsNotDefined = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Undefined<Type> =>
+  callback(
+    typeOf(value) === 'undefined' &&
+    typeof value === 'undefined' &&
+    value === undefined,
+    value
+  );

--- a/src/is/not/lib/is-not-function.func.ts
+++ b/src/is/not/lib/is-not-function.func.ts
@@ -2,13 +2,23 @@
 import { resultCallback } from '../../../lib/result-callback.func';
 import { typeOf } from '../../../lib/type-of.func';
 // Type.
+import { Func } from 'type';
 import { IsNotFunction } from '../type/is-not-function.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
 /**
- * Checks if an unknown `value` is not a `function` type and not an instance of `Function`.
- * @param value An unknown `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
+ * Checks if a generic `Type` `value` is not a `function` type and not an instance of `Function`.
+ * @param value A generic `Type` `value`, by default of type detected from the `value`, to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is not a `function`.
  */
-export const isNotFunction: IsNotFunction = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'function' && typeof value !== 'function' && value instanceof Function === false, value);
+export const isNotFunction: IsNotFunction = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<Func, Type> =>
+  callback(
+    typeOf(value) !== 'function' &&
+    typeof value !== 'function' &&
+    value instanceof Function === false,
+    value
+  );

--- a/src/is/not/lib/is-not-function.func.ts
+++ b/src/is/not/lib/is-not-function.func.ts
@@ -2,7 +2,7 @@
 import { resultCallback } from '../../../lib/result-callback.func';
 import { typeOf } from '../../../lib/type-of.func';
 // Type.
-import { Func } from 'type';
+import { Func } from '../../../type/func.type';
 import { IsNotFunction } from '../type/is-not-function.type';
 import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';

--- a/src/is/not/lib/is-not-null.func.ts
+++ b/src/is/not/lib/is-not-null.func.ts
@@ -4,11 +4,15 @@ import { typeOf } from '../../../lib/type-of.func';
 // Type.
 import { IsNotNull } from '../type/is-not-null.type';
 import { ResultCallback } from '../../../type/result-callback.type';
+import { Never } from '../../../type/never.type';
 /**
- * Checks if an unknown `value` is not a `null` type and not equal to `null`.
- * @param value An unknown `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
+ * Checks if a generic `Type` `value` is not a `null` type and not equal to `null`.
+ * @param value A generic `Type` `value`, by default of type detected from the `value` to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is not `null`.
  */
-export const isNotNull: IsNotNull = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
+export const isNotNull: IsNotNull = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<null, Type> =>
   callback(typeOf(value) !== 'null' && value !== null, value);

--- a/src/is/not/lib/is-not-number.func.ts
+++ b/src/is/not/lib/is-not-number.func.ts
@@ -2,16 +2,20 @@
 import { resultCallback } from '../../../lib/result-callback.func';
 import { typeOf } from '../../../lib/type-of.func';
 // Type.
+import { AnyNumber } from 'dist/type/type/any-number.type';
 import { IsNotNumber } from '../type/is-not-number.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
-
 /**
- * Checks if any `value` is not a `number` type and not an instance of `Number`.
- * @param value An unknown `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
- * @returns A `boolean` indicating whether or not the `value` is not a `number`.
+ * Checks if a generic `Type` `value` is not a `number` type and not an instance of `Number`.
+ * @param value A generic `Type`, by default of type detected from the `value` to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
+ * @returns A `boolean` indicating whether or not the `value` is not a `number` or `Number` instance.
  */
-export const isNotNumber: IsNotNumber = (value: any, callback: ResultCallback = resultCallback): boolean =>
+export const isNotNumber: IsNotNumber = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<AnyNumber, Type> =>
   callback(
     typeOf(value) !== 'number' &&
     typeof value !== 'number' &&

--- a/src/is/not/lib/is-not-number.func.ts
+++ b/src/is/not/lib/is-not-number.func.ts
@@ -2,7 +2,7 @@
 import { resultCallback } from '../../../lib/result-callback.func';
 import { typeOf } from '../../../lib/type-of.func';
 // Type.
-import { AnyNumber } from 'dist/type/type/any-number.type';
+import { AnyNumber } from '../../../type/any-number.type';
 import { IsNotNumber } from '../type/is-not-number.type';
 import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';

--- a/src/is/not/lib/is-not-string.func.ts
+++ b/src/is/not/lib/is-not-string.func.ts
@@ -2,13 +2,23 @@
 import { resultCallback } from '../../../lib/result-callback.func';
 import { typeOf } from '../../../lib/type-of.func';
 // Type.
+import { AnyString } from '../../../type/any-string.type';
 import { IsNotString } from '../type/is-not-string.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
 /**
- * Checks if an unknown `value` is not a `string` type and not an instance of `String`.
- * @param value An unknown `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
- * @returns A `boolean` indicating whether or not the `value` is not a `string`.
+ * Checks if a generic `Type` `value` is not a `string` type and not an instance of `String`.
+ * @param value A generic `Type`, by default of type detected from the `value` to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
+ * @returns A `boolean` indicating whether or not the `value` is not a `string` or `String` instance.
  */
-export const isNotString: IsNotString = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'string' && typeof value !== 'string' && value instanceof String === false, value);
+export const isNotString: IsNotString = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Never<AnyString, Type> =>
+  callback(
+    typeOf(value) !== 'string' &&
+    typeof value !== 'string' &&
+    value instanceof String === false,
+    value
+  );

--- a/src/is/not/lib/is-not-undefined.func.ts
+++ b/src/is/not/lib/is-not-undefined.func.ts
@@ -2,13 +2,22 @@
 import { resultCallback } from '../../../lib/result-callback.func';
 import { typeOf } from '../../../lib/type-of.func';
 // Type.
+import { Defined } from '../../../type/defined.type';
 import { IsNotUndefined } from '../type/is-not-undefined.type';
 import { ResultCallback } from '../../../type/result-callback.type';
 /**
- * Checks if an unknown `value` is NOT an `undefined` type and NOT equal to `undefined`.
- * @param value An unknown `value` to check.
- * @param callback `ResultCallback` function to handle result before returns.
+ * Checks if a generic `Type` `value` is not an `undefined` type and not equal to `undefined`.
+ * @param value A generic `Type` `value`, by default of type detected from the `value`, to check.
+ * @param callback A `ResultCallback` function to handle the result before returns.
  * @returns A `boolean` indicating whether or not the `value` is not `undefined`.
  */
-export const isNotUndefined: IsNotUndefined = (value: unknown, callback: ResultCallback = resultCallback): boolean =>
-  callback(typeOf(value) !== 'undefined' && typeof value !== 'undefined' && value !== undefined, value);
+export const isNotUndefined: IsNotUndefined = <Type>(
+  value: Type,
+  callback: ResultCallback = resultCallback
+): value is Defined<Type> =>
+  callback(
+    typeOf(value) !== 'undefined' &&
+    typeof value !== 'undefined' &&
+    value !== undefined,
+    value
+  );

--- a/src/is/not/type/is-not-boolean.type.ts
+++ b/src/is/not/type/is-not-boolean.type.ts
@@ -1,2 +1,4 @@
+import { AnyBoolean } from '../../../type/any-boolean.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
-export type IsNotBoolean = (value: unknown, callback?: ResultCallback) => boolean;
+export type IsNotBoolean = <Type>(value: Type, callback?: ResultCallback) => value is Never<AnyBoolean, Type>;

--- a/src/is/not/type/is-not-defined.type.ts
+++ b/src/is/not/type/is-not-defined.type.ts
@@ -1,2 +1,3 @@
 import { ResultCallback } from '../../../type/result-callback.type';
-export type IsNotDefined = (value: unknown, callback?: ResultCallback) => boolean;
+import { Undefined } from '../../../type/undefined.type';
+export type IsNotDefined = <Type>(value: Type, callback?: ResultCallback) => value is Undefined<Type>;

--- a/src/is/not/type/is-not-function.type.ts
+++ b/src/is/not/type/is-not-function.type.ts
@@ -1,2 +1,4 @@
+import { Func } from '../../../type/func.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
-export type IsNotFunction = (value: unknown, callback?: ResultCallback) => boolean;
+export type IsNotFunction = <Type>(value: Type, callback?: ResultCallback) => value is Never<Func, Type>;

--- a/src/is/not/type/is-not-null.type.ts
+++ b/src/is/not/type/is-not-null.type.ts
@@ -1,2 +1,3 @@
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
-export type IsNotNull = (value: unknown, callback?: ResultCallback) => boolean;
+export type IsNotNull = <Type>(value: Type, callback?: ResultCallback) => value is Never<null, Type>;

--- a/src/is/not/type/is-not-number.type.ts
+++ b/src/is/not/type/is-not-number.type.ts
@@ -1,2 +1,4 @@
+import { AnyNumber } from '../../../type/any-number.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
-export type IsNotNumber = (value: any, callback?: ResultCallback) => boolean;
+export type IsNotNumber = <Type>(value: Type, callback?: ResultCallback) => value is Never<AnyNumber, Type>;

--- a/src/is/not/type/is-not-string.type.ts
+++ b/src/is/not/type/is-not-string.type.ts
@@ -1,2 +1,4 @@
+import { AnyString } from '../../../type/any-string.type';
+import { Never } from '../../../type/never.type';
 import { ResultCallback } from '../../../type/result-callback.type';
-export type IsNotString = (value: unknown, callback?: ResultCallback) => boolean;
+export type IsNotString = <Type>(value: Type, callback?: ResultCallback) => value is Never<AnyString, Type>;

--- a/src/is/not/type/is-not-undefined.type.ts
+++ b/src/is/not/type/is-not-undefined.type.ts
@@ -1,2 +1,3 @@
+import { Defined } from '../../../type/defined.type';
 import { ResultCallback } from '../../../type/result-callback.type';
-export type IsNotUndefined = (value: unknown, callback?: ResultCallback) =>  boolean;
+export type IsNotUndefined = <Type>(value: Type, callback?: ResultCallback) => value is Defined<Type>;

--- a/src/is/type/is-defined.type.ts
+++ b/src/is/type/is-defined.type.ts
@@ -1,2 +1,3 @@
+import { Defined } from '../../type/defined.type';
 import { ResultCallback } from '../../type/result-callback.type';
-export type IsDefined = (value: unknown, callback?: ResultCallback) => boolean;
+export type IsDefined = <Type>(value: Type, callback?: ResultCallback) => value is Defined<Type>;

--- a/src/type/any-boolean.type.ts
+++ b/src/type/any-boolean.type.ts
@@ -1,2 +1,3 @@
+// Represents `boolean` type or `Boolean` object.
 // tslint:disable-next-line: ban-types
 export type AnyBoolean = Exclude<boolean | Boolean, true | false>;

--- a/src/type/any-number.type.ts
+++ b/src/type/any-number.type.ts
@@ -1,2 +1,3 @@
+// Represents `number` type or `Number` object.
 // tslint:disable-next-line: ban-types
 export type AnyNumber = number | Number;

--- a/src/type/any-string.type.ts
+++ b/src/type/any-string.type.ts
@@ -1,2 +1,3 @@
+// Represents `string` type or `String` object.
 // tslint:disable-next-line: ban-types
 export type AnyString = string | String;

--- a/src/type/defined.type.ts
+++ b/src/type/defined.type.ts
@@ -1,1 +1,2 @@
-export type Defined<T> = T extends undefined ? never : T;
+import { Never } from './never.type';
+export type Defined<Type> = Never<undefined, Type>;

--- a/src/type/never.type.ts
+++ b/src/type/never.type.ts
@@ -1,0 +1,2 @@
+// Choose a type to exclude. A generic `Type` is never a `Not` type.
+export type Never<Not, Type> = Type extends Not ? never : Type;

--- a/src/type/undefined.type.ts
+++ b/src/type/undefined.type.ts
@@ -1,0 +1,2 @@
+// Undefined or `never` - treat types as `never` excluding `undefined`.
+export type Undefined<Type> = Type extends undefined ? Type : never;


### PR DESCRIPTION
Update README.md

Fix:
* Fixes the return type `boolean`, which doesn't strictly indicate the `value` is defined by changing the `value` type to a generic `Type` and the return type to `value is Defined<Type>` 9154c07
* All `isNot` prefixed functions to strictly indicate value is not a type 1c86751